### PR TITLE
refactor: unify component elements API across all widgets

### DIFF
--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 
-	import { defineScenaElement } from '@/app/custom-element';
-	import { useScena } from '@/app/entrypoint';
+	import { type ScenaInstance, useScena } from '@/app/entrypoint';
 	import { ScenaEvent } from '@/entities/event';
 	import { ComponentShape, ComponentSize } from '@/shared/enums';
 
 	const widget = useScena();
 
-	defineScenaElement();
+	let instance: ScenaInstance;
 
 	onMount(async () => {
-		const instance = await widget.mount({
+		instance = await widget.mount({
 			shape: ComponentShape.PORTRAIT,
 			video: {
 				src: './examples/example-dog.mp4',
@@ -46,6 +45,10 @@
 		instance.api.events.on(ScenaEvent.ON_VISIBILITY_SHOW, () => {
 			console.log(instance.visibility);
 		});
+	});
+
+	onDestroy(() => {
+		widget.unmount(instance);
 	});
 </script>
 

--- a/src/app/entrypoint/ui/Scena.svelte
+++ b/src/app/entrypoint/ui/Scena.svelte
@@ -115,7 +115,6 @@
 
 	onMount(() => {
 		mount();
-		eventEmitter.emit(ScenaEvent.ON_SCENA_MOUNT);
 	});
 
 	onDestroy(() => {

--- a/src/entities/event/model/enums/index.ts
+++ b/src/entities/event/model/enums/index.ts
@@ -1,7 +1,5 @@
 /** Event names emitted by the scena widget event bus. */
 export enum ScenaEvent {
-	/** Fired when the scena component is mounted in the DOM. */
-	ON_SCENA_MOUNT = 'scena:on-mount',
 	/** Fired when the scena instance is destroyed. */
 	ON_SCENA_DESTROY = 'scena:on-destroy',
 

--- a/src/shared/types/components/index.ts
+++ b/src/shared/types/components/index.ts
@@ -1,5 +1,8 @@
 import { ComponentAriaHaspopup, ComponentAriaPressed } from '../../enums';
 
+/** Shape of any component instance that exposes its DOM elements via `getElements()`. */
+export type ComponentRef<T> = { getElements(): T };
+
 /** Inline styles — a raw CSS string or a partial `CSSStyleDeclaration` object. */
 export type ComponentStyles = string | Partial<CSSStyleDeclaration>;
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,2 +1,7 @@
-export type { ComponentClasses, ComponentStyles, ComponentAriaProps } from './components';
+export type {
+	ComponentRef,
+	ComponentClasses,
+	ComponentStyles,
+	ComponentAriaProps
+} from './components';
 export type { ComponentSnippetReturn, ComponentSnippet } from './snippet';

--- a/src/shared/ui/scena-button/model/types/index.ts
+++ b/src/shared/ui/scena-button/model/types/index.ts
@@ -43,5 +43,5 @@ export interface ScenaButtonSnippets {
 
 /** DOM element references for the base button. */
 export interface ScenaButtonElements {
-	root: HTMLButtonElement;
+	root: HTMLButtonElement | null;
 }

--- a/src/shared/ui/scena-button/ui/ScenaButton.svelte
+++ b/src/shared/ui/scena-button/ui/ScenaButton.svelte
@@ -3,7 +3,12 @@
 	import { formatComponentStyles } from '@/shared/utils';
 
 	import { ScenaButtonShape, ScenaButtonType, ScenaButtonVariant } from '../model';
-	import type { ScenaButtonProps, ScenaButtonEvents, ScenaButtonSnippets } from '../model';
+	import type {
+		ScenaButtonElements,
+		ScenaButtonProps,
+		ScenaButtonEvents,
+		ScenaButtonSnippets
+	} from '../model';
 
 	let {
 		id,
@@ -27,12 +32,14 @@
 		customClasses?.root
 	]);
 
-	let rootElement: HTMLButtonElement;
+	let rootElement: HTMLButtonElement | null = $state(null);
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
-		return { root: rootElement };
+	export function getElements(): ScenaButtonElements {
+		return {
+			root: rootElement
+		};
 	}
 </script>
 

--- a/src/shared/ui/scena-icons/model/types/index.ts
+++ b/src/shared/ui/scena-icons/model/types/index.ts
@@ -22,5 +22,5 @@ export interface ScenaIconSnippets {
 }
 
 export interface ScenaIconElements {
-	root: SVGSVGElement;
+	root: SVGSVGElement | null;
 }

--- a/src/shared/ui/scena-icons/ui/ScenaIcon.svelte
+++ b/src/shared/ui/scena-icons/ui/ScenaIcon.svelte
@@ -2,7 +2,7 @@
 	import { ComponentSize } from '@/shared/enums';
 	import { formatComponentStyles } from '@/shared/utils';
 
-	import type { ScenaIconProps, ScenaIconSnippets } from '../model';
+	import type { ScenaIconElements, ScenaIconProps, ScenaIconSnippets } from '../model';
 
 	let {
 		id,
@@ -13,14 +13,16 @@
 		children
 	}: Partial<ScenaIconProps & ScenaIconSnippets> = $props();
 
-	let rootElement: SVGSVGElement;
+	let rootElement: SVGSVGElement | null = $state(null);
 
 	const rootClasses = $derived(['rs-icon', `rs-icon--${size}`, customClasses?.root]);
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
-		return { root: rootElement };
+	export function getElements(): ScenaIconElements {
+		return {
+			root: rootElement
+		};
 	}
 </script>
 

--- a/src/shared/ui/scena-loader/model/types/index.ts
+++ b/src/shared/ui/scena-loader/model/types/index.ts
@@ -21,5 +21,5 @@ export interface ScenaLoaderProps {
 
 /** DOM element references for the loader spinner. */
 export interface ScenaLoaderElements {
-	root: SVGSVGElement;
+	root: SVGSVGElement | null;
 }

--- a/src/shared/ui/scena-loader/ui/ScenaLoader.svelte
+++ b/src/shared/ui/scena-loader/ui/ScenaLoader.svelte
@@ -2,7 +2,7 @@
 	import { ComponentSize } from '@/shared/enums';
 	import { formatComponentStyles } from '@/shared/utils';
 
-	import type { ScenaLoaderProps } from '../model';
+	import type { ScenaLoaderElements, ScenaLoaderProps } from '../model';
 
 	let {
 		id,
@@ -11,14 +11,16 @@
 		customStyles
 	}: Partial<ScenaLoaderProps> = $props();
 
-	let rootElement: SVGSVGElement;
+	let rootElement: SVGSVGElement | null = $state(null);
 
 	const rootClasses = $derived(['rs-loader', `rs-loader--${size}`, customClasses?.root]);
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
-		return { root: rootElement };
+	export function getElements(): ScenaLoaderElements {
+		return {
+			root: rootElement
+		};
 	}
 </script>
 

--- a/src/shared/ui/scena-progress/model/lib/useProgressCircle.svelte.ts
+++ b/src/shared/ui/scena-progress/model/lib/useProgressCircle.svelte.ts
@@ -42,6 +42,16 @@ export default function useProgressCircle({
 
 	const radialBufferOffset = $derived(radialCircumference * (1 - getBuffer()));
 
+	function getRootElementSafe(): SVGSVGElement {
+		const root = getRootElement();
+
+		if (!root) {
+			throw new Error('Progress root element is not available');
+		}
+
+		return root;
+	}
+
 	function getPercentFromClientPoint(clientX: number, clientY: number, element: Element): number {
 		const rect = element.getBoundingClientRect();
 
@@ -75,7 +85,7 @@ export default function useProgressCircle({
 	}
 
 	function onTrackPointerDown(event: PointerEvent): void {
-		getRootElement().focus();
+		getRootElementSafe().focus();
 
 		isFocused = true;
 		isDragging = true;
@@ -140,7 +150,7 @@ export default function useProgressCircle({
 	});
 
 	onMount(() => {
-		resizeObserver.observe(getRootElement());
+		resizeObserver.observe(getRootElementSafe());
 	});
 
 	onDestroy(() => {

--- a/src/shared/ui/scena-progress/model/lib/useProgressLine.svelte.ts
+++ b/src/shared/ui/scena-progress/model/lib/useProgressLine.svelte.ts
@@ -23,6 +23,16 @@ export default function useProgressLine({
 
 	const transition = $derived(isDisabledTransition ? 'none' : undefined);
 
+	function getRootElementSafe(): HTMLElement {
+		const root = getRootElement();
+
+		if (!root) {
+			throw new Error('Progress root element is not available');
+		}
+
+		return root;
+	}
+
 	function getEventProgress(event: PointerEvent, element: Element): number {
 		const rect = element.getBoundingClientRect();
 
@@ -54,7 +64,7 @@ export default function useProgressLine({
 	}
 
 	function onPointerDown(event: PointerEvent): void {
-		getRootElement().focus();
+		getRootElementSafe().focus();
 
 		isDragging = true;
 

--- a/src/shared/ui/scena-progress/model/types/index.ts
+++ b/src/shared/ui/scena-progress/model/types/index.ts
@@ -105,8 +105,8 @@ export interface UseProgressLineReturn {
 /** Props accepted by the line progress hook. */
 export interface UseProgressLineProps {
 	getRootElement: () => HTMLElement;
-	getSize: () => ComponentSize;
 	getCustomThickness: () => ScenaProgressComponentThickness;
+	getSize: () => ComponentSize;
 	getProgress: () => number;
 }
 
@@ -119,9 +119,9 @@ export interface UseProgressLineEvents {
 
 /** Props accepted by the circle progress hook. */
 export interface UseProgressCircleProps {
-	getRootElement: () => SVGSVGElement;
-	getSize: () => ComponentSize;
+	getRootElement: () => SVGSVGElement | null;
 	getCustomThickness: () => ScenaProgressComponentThickness;
+	getSize: () => ComponentSize;
 	getProgress: () => number;
 	getBuffer: () => number;
 }
@@ -146,7 +146,7 @@ export interface UseProgressCircleReturnEvents {
 
 /** DOM element references for the linear progress bar. */
 export interface ScenaProgressLineElements {
-	root: HTMLDivElement;
+	root: HTMLDivElement | null;
 	track: HTMLDivElement;
 	buffer: HTMLDivElement | null;
 	progress: HTMLDivElement;
@@ -154,7 +154,7 @@ export interface ScenaProgressLineElements {
 
 /** DOM element references for the circular progress indicator. */
 export interface ScenaProgressCircleElements {
-	root: SVGSVGElement;
+	root: SVGSVGElement | null;
 	track: SVGCircleElement | null;
 	buffer: SVGCircleElement | null;
 	progress: SVGCircleElement | null;

--- a/src/shared/ui/scena-progress/ui/ScenaProgressCircle.svelte
+++ b/src/shared/ui/scena-progress/ui/ScenaProgressCircle.svelte
@@ -3,7 +3,11 @@
 	import { formatComponentStyles } from '@/shared/utils';
 
 	import { useProgressCircle, scenaProgressCircleThicknessMap } from '../model';
-	import type { ScenaProgressCircleEvents, ScenaProgressCircleProps } from '../model';
+	import type {
+		ScenaProgressCircleElements,
+		ScenaProgressCircleEvents,
+		ScenaProgressCircleProps
+	} from '../model';
 
 	let {
 		id,
@@ -20,7 +24,7 @@
 		onSeekEnd
 	}: Partial<ScenaProgressCircleProps & ScenaProgressCircleEvents> = $props();
 
-	let rootElement: SVGSVGElement;
+	let rootElement: SVGSVGElement | null = $state(null);
 
 	let trackElement: SVGCircleElement | null = $state(null);
 
@@ -58,7 +62,7 @@
 		})
 	});
 
-	export function getElements() {
+	export function getElements(): ScenaProgressCircleElements {
 		return {
 			root: rootElement,
 			track: trackElement,

--- a/src/shared/ui/scena-progress/ui/ScenaProgressLine.svelte
+++ b/src/shared/ui/scena-progress/ui/ScenaProgressLine.svelte
@@ -3,7 +3,11 @@
 	import { formatComponentStyles } from '@/shared/utils';
 
 	import { useProgressLine, scenaProgressLineThicknessMap } from '../model';
-	import type { ScenaProgressLineEvents, ScenaProgressLineProps } from '../model';
+	import type {
+		ScenaProgressLineElements,
+		ScenaProgressLineEvents,
+		ScenaProgressLineProps
+	} from '../model';
 
 	let {
 		id,
@@ -20,7 +24,7 @@
 		onSeekEnd
 	}: Partial<ScenaProgressLineProps & ScenaProgressLineEvents> = $props();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
 	let trackElement: HTMLDivElement;
 
@@ -44,7 +48,7 @@
 
 	const progressStyles = $derived(formatComponentStyles(customStyles?.progress));
 
-	export function getElements() {
+	export function getElements(): ScenaProgressLineElements {
 		return {
 			root: rootElement,
 			track: trackElement,
@@ -54,7 +58,7 @@
 	}
 
 	const progressLine = useProgressLine({
-		getRootElement: () => rootElement,
+		getRootElement: () => rootElement!,
 		getProgress: () => progress,
 		getSize: () => size,
 		onSeek: (progress, event) => onSeek?.(progress, event),

--- a/src/shared/utils/components/format-component-style-property/index.ts
+++ b/src/shared/utils/components/format-component-style-property/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Converts a camelCase property name to a kebab-case CSS property.
+ */
+export const formatComponentStyleProperty = (propertyName: string): string => {
+	return propertyName.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+};

--- a/src/shared/utils/components/format-component-styles/index.ts
+++ b/src/shared/utils/components/format-component-styles/index.ts
@@ -1,0 +1,22 @@
+import type { ComponentStyles } from '@/shared/types';
+
+import { formatComponentStyleProperty } from '../';
+
+/**
+ * Converts a `ComponentStyles` value (string or object) into an inline CSS string.
+ */
+export const formatComponentStyles = (styles: ComponentStyles | undefined): string | undefined => {
+	if (!styles) {
+		return undefined;
+	}
+
+	if (typeof styles === 'string') {
+		return styles;
+	}
+
+	return (
+		Object.entries(styles)
+			.map(([property, value]) => `${formatComponentStyleProperty(property)}: ${value}`)
+			.join('; ') + ';'
+	);
+};

--- a/src/shared/utils/components/index.ts
+++ b/src/shared/utils/components/index.ts
@@ -1,27 +1,3 @@
-import type { ComponentStyles } from '../../types';
-
-/**
- * Converts a camelCase property name to a kebab-case CSS property.
- */
-export const formatComponentStyleProperty = (propertyName: string): string => {
-	return propertyName.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
-};
-
-/**
- * Converts a `ComponentStyles` value (string or object) into an inline CSS string.
- */
-export const formatComponentStyles = (styles: ComponentStyles | undefined): string | undefined => {
-	if (!styles) {
-		return undefined;
-	}
-
-	if (typeof styles === 'string') {
-		return styles;
-	}
-
-	return (
-		Object.entries(styles)
-			.map(([property, value]) => `${formatComponentStyleProperty(property)}: ${value}`)
-			.join('; ') + ';'
-	);
-};
+export { formatComponentStyleProperty } from './format-component-style-property';
+export { formatComponentStyles } from './format-component-styles';
+export { resolveElements } from './resolve-elements';

--- a/src/shared/utils/components/resolve-elements/index.ts
+++ b/src/shared/utils/components/resolve-elements/index.ts
@@ -1,0 +1,10 @@
+import type { ComponentRef } from '@/shared/types';
+
+/**
+ * Calls `getElements()` on a component instance, returning `null` when the instance is unbound.
+ * Keeps the return type consistently `T | null` instead of mixing `null` (unbound) and
+ * `undefined` (optional chaining result).
+ */
+export const resolveElements = <T>(instance: ComponentRef<T> | null): T | null => {
+	return instance?.getElements() ?? null;
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,3 +1,3 @@
-export { formatComponentStyleProperty, formatComponentStyles } from './components';
+export { formatComponentStyleProperty, formatComponentStyles, resolveElements } from './components';
 export { isBrowser } from './environment';
 export { deepClone, deepMerge, pick } from './objects';

--- a/src/widgets/scena-container/model/types/index.ts
+++ b/src/widgets/scena-container/model/types/index.ts
@@ -27,7 +27,12 @@ export interface ScenaContainerSnippets {
 	children: ComponentSnippet;
 }
 
+/** DOM elements exposed by the outer container component. */
+export interface ScenaContainerElements {
+	root: HTMLDivElement | null;
+}
+
 /** Component ref for the outer container. */
 export interface ScenaContainerRef {
-	getElements: () => { root: HTMLDivElement };
+	getElements: () => ScenaContainerElements;
 }

--- a/src/widgets/scena-container/ui/ScenaContainer.svelte
+++ b/src/widgets/scena-container/ui/ScenaContainer.svelte
@@ -2,7 +2,11 @@
 	import { ComponentPlacement, ComponentPosition } from '@/shared/enums';
 	import { formatComponentStyles } from '@/shared/utils';
 
-	import type { ScenaContainerProps, ScenaContainerSnippets } from '../model';
+	import type {
+		ScenaContainerElements,
+		ScenaContainerProps,
+		ScenaContainerSnippets
+	} from '../model';
 
 	let {
 		id,
@@ -13,7 +17,7 @@
 		children
 	}: Partial<ScenaContainerProps & ScenaContainerSnippets> = $props();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
 	const customPlacements = [ComponentPosition.ABSOLUTE, ComponentPosition.FIXED];
 
@@ -28,8 +32,10 @@
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
-		return { root: rootElement };
+	export function getElements(): ScenaContainerElements {
+		return {
+			root: rootElement
+		};
 	}
 </script>
 

--- a/src/widgets/scena-controls/model/types/index.ts
+++ b/src/widgets/scena-controls/model/types/index.ts
@@ -28,11 +28,14 @@ export interface ScenaCloseButtonProps {
 	onClick: (event: Event) => void;
 }
 
+/** DOM elements exposed by the close button component. */
+export interface ScenaCloseButtonElements {
+	root: HTMLDivElement | null;
+	cross: ScenaIconElements | null;
+	button: ScenaButtonElements | null;
+}
+
 /** Component ref for the close button. */
 export interface ScenaCloseButtonRef {
-	getElements: () => {
-		root: HTMLDivElement;
-		button: ScenaButtonElements | undefined;
-		cross: ScenaIconElements | undefined;
-	};
+	getElements: () => ScenaCloseButtonElements;
 }

--- a/src/widgets/scena-controls/ui/ScenaCloseButton.svelte
+++ b/src/widgets/scena-controls/ui/ScenaCloseButton.svelte
@@ -5,9 +5,9 @@
 	import { ComponentSize, ComponentShape } from '@/shared/enums';
 	import { ScenaButton, ScenaButtonShape, ScenaButtonVariant } from '@/shared/ui/scena-button';
 	import { ScenaIcon } from '@/shared/ui/scena-icons';
-	import { formatComponentStyles } from '@/shared/utils';
+	import { formatComponentStyles, resolveElements } from '@/shared/utils';
 
-	import type { ScenaCloseButtonProps } from '../model';
+	import type { ScenaCloseButtonElements, ScenaCloseButtonProps } from '../model';
 
 	let {
 		id,
@@ -21,11 +21,11 @@
 
 	const { eventEmitter, unmount } = getScenaContext();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
-	let buttonElement: ScenaButton;
+	let buttonElement: ScenaButton | null = $state(null);
 
-	let crossElement: ScenaIcon;
+	let crossElement: ScenaIcon | null = $state(null);
 
 	const rootClasses = $derived([
 		'rs-close-button',
@@ -47,11 +47,11 @@
 		unmount();
 	}
 
-	export function getElements() {
+	export function getElements(): ScenaCloseButtonElements {
 		return {
 			root: rootElement,
-			button: buttonElement?.getElements(),
-			cross: crossElement?.getElements()
+			button: resolveElements(buttonElement),
+			cross: resolveElements(crossElement)
 		};
 	}
 </script>

--- a/src/widgets/scena-cta/model/types/index.ts
+++ b/src/widgets/scena-cta/model/types/index.ts
@@ -35,10 +35,13 @@ export interface ScenaCtaButtonProps {
 	onClick: (event: Event) => void;
 }
 
+/** DOM elements exposed by the CTA button component. */
+export interface ScenaCtaButtonElements {
+	root: HTMLDivElement | null;
+	button: ScenaButtonElements | null;
+}
+
 /** Component ref for the CTA button. */
 export interface ScenaCtaButtonRef {
-	getElements: () => {
-		root: HTMLDivElement;
-		button: ScenaButtonElements | undefined;
-	};
+	getElements: () => ScenaCtaButtonElements;
 }

--- a/src/widgets/scena-cta/ui/ScenaCtaButton.svelte
+++ b/src/widgets/scena-cta/ui/ScenaCtaButton.svelte
@@ -3,9 +3,13 @@
 	import { getScenaContext } from '@/entities/scena';
 	import { ComponentSize } from '@/shared/enums';
 	import { ScenaButton, ScenaButtonShape } from '@/shared/ui/scena-button';
-	import { formatComponentStyles } from '@/shared/utils';
+	import { formatComponentStyles, resolveElements } from '@/shared/utils';
 
-	import { ScenaCtaButtonPlacement, type ScenaCtaButtonProps } from '../model';
+	import {
+		ScenaCtaButtonPlacement,
+		type ScenaCtaButtonElements,
+		type ScenaCtaButtonProps
+	} from '../model';
 
 	let {
 		id,
@@ -28,9 +32,9 @@
 		adaptive && adaptive.sizes.includes(size) ? adaptive.placement : placement
 	);
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
-	let buttonElement: ScenaButton;
+	let buttonElement: ScenaButton | null = $state(null);
 
 	const rootClasses = $derived([
 		'rs-cta-button',
@@ -48,10 +52,10 @@
 		}
 	}
 
-	export function getElements() {
+	export function getElements(): ScenaCtaButtonElements {
 		return {
 			root: rootElement,
-			button: buttonElement?.getElements()
+			button: resolveElements(buttonElement)
 		};
 	}
 </script>

--- a/src/widgets/scena-video-container/model/types/index.ts
+++ b/src/widgets/scena-video-container/model/types/index.ts
@@ -34,7 +34,12 @@ export interface ScenaVideoContainerSnippets {
 	children: ComponentSnippet;
 }
 
+/** DOM elements exposed by the video container component. */
+export interface ScenaVideoContainerElements {
+	root: HTMLDivElement | null;
+}
+
 /** Component ref for the video container. */
 export interface ScenaVideoContainerRef {
-	getElements: () => { root: HTMLDivElement };
+	getElements: () => ScenaVideoContainerElements;
 }

--- a/src/widgets/scena-video-container/ui/ScenaVideoContainer.svelte
+++ b/src/widgets/scena-video-container/ui/ScenaVideoContainer.svelte
@@ -4,7 +4,11 @@
 	import { ComponentSize, ComponentShape } from '@/shared/enums';
 	import { formatComponentStyles } from '@/shared/utils';
 
-	import type { ScenaVideoContainerProps, ScenaVideoContainerSnippets } from '../model';
+	import type {
+		ScenaVideoContainerElements,
+		ScenaVideoContainerProps,
+		ScenaVideoContainerSnippets
+	} from '../model';
 
 	let {
 		id,
@@ -18,7 +22,7 @@
 
 	const { eventEmitter } = getScenaContext();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
 	const rootClasses = $derived([
 		'rs-video-container',
@@ -40,8 +44,10 @@
 		}
 	}
 
-	export function getElements() {
-		return { root: rootElement };
+	export function getElements(): ScenaVideoContainerElements {
+		return {
+			root: rootElement
+		};
 	}
 </script>
 

--- a/src/widgets/scena-video-controls/model/types/index.ts
+++ b/src/widgets/scena-video-controls/model/types/index.ts
@@ -32,13 +32,16 @@ export interface ScenaVideoControlsProps {
 	customStyles: Partial<ScenaVideoControlsComponentStyles>;
 }
 
+/** DOM elements exposed by the video controls component. */
+export interface ScenaVideoControlsElements {
+	root: HTMLDivElement | null;
+	pauseButton: ScenaButtonElements | null;
+	pauseIcon: ScenaIconElements | null;
+	playButton: ScenaButtonElements | null;
+	playIcon: ScenaIconElements | null;
+}
+
 /** Component ref for the video play/pause controls. */
 export interface ScenaVideoControlsRef {
-	getElements: () => {
-		root: HTMLDivElement | null;
-		pauseButton: ScenaButtonElements | undefined;
-		pauseIcon: ScenaIconElements | undefined;
-		playButton: ScenaButtonElements | undefined;
-		playIcon: ScenaIconElements | undefined;
-	};
+	getElements: () => ScenaVideoControlsElements;
 }

--- a/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
+++ b/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
@@ -4,9 +4,9 @@
 	import { ComponentSize } from '@/shared/enums';
 	import { ScenaButton, ScenaButtonShape, ScenaButtonVariant } from '@/shared/ui/scena-button';
 	import { ScenaIcon } from '@/shared/ui/scena-icons';
-	import { formatComponentStyles } from '@/shared/utils';
+	import { formatComponentStyles, resolveElements } from '@/shared/utils';
 
-	import type { ScenaVideoControlsProps } from '../model';
+	import type { ScenaVideoControlsElements, ScenaVideoControlsProps } from '../model';
 
 	let {
 		id,
@@ -43,13 +43,13 @@
 
 	const isShownPlay = $derived([ScenaVideoState.IDLE, ScenaVideoState.PAUSED].includes(videoState));
 
-	export function getElements() {
+	export function getElements(): ScenaVideoControlsElements {
 		return {
 			root: rootElement,
-			pauseButton: pauseButtonElement?.getElements(),
-			pauseIcon: pauseIconElement?.getElements(),
-			playButton: playButtonElement?.getElements(),
-			playIcon: playIconElement?.getElements()
+			pauseButton: resolveElements(pauseButtonElement),
+			pauseIcon: resolveElements(pauseIconElement),
+			playButton: resolveElements(playButtonElement),
+			playIcon: resolveElements(playIconElement)
 		};
 	}
 </script>

--- a/src/widgets/scena-video-loader/model/types/index.ts
+++ b/src/widgets/scena-video-loader/model/types/index.ts
@@ -22,10 +22,13 @@ export interface ScenaVideoLoaderProps {
 	customStyles: Partial<ScenaVideoLoaderComponentStyles>;
 }
 
+/** DOM elements exposed by the video loader component. */
+export interface ScenaVideoLoaderElements {
+	root: HTMLDivElement | null;
+	loader: ScenaLoaderElements | null;
+}
+
 /** Component ref for the video loader. */
 export interface ScenaVideoLoaderRef {
-	getElements: () => {
-		root: HTMLDivElement;
-		loader: ScenaLoaderElements | undefined;
-	};
+	getElements: () => ScenaVideoLoaderElements;
 }

--- a/src/widgets/scena-video-loader/ui/ScenaVideoLoader.svelte
+++ b/src/widgets/scena-video-loader/ui/ScenaVideoLoader.svelte
@@ -2,9 +2,9 @@
 	import { getScenaVideoContext, ScenaVideoState } from '@/entities/video';
 	import { ComponentSize } from '@/shared/enums';
 	import { ScenaLoader } from '@/shared/ui/scena-loader';
-	import { formatComponentStyles } from '@/shared/utils';
+	import { formatComponentStyles, resolveElements } from '@/shared/utils';
 
-	import type { ScenaVideoLoaderProps } from '../model';
+	import type { ScenaVideoLoaderElements, ScenaVideoLoaderProps } from '../model';
 
 	let {
 		id,
@@ -15,7 +15,7 @@
 
 	const scenaVideoContext = getScenaVideoContext();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
 	let loaderElement: ScenaLoader | null = $state(null);
 
@@ -23,10 +23,10 @@
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
+	export function getElements(): ScenaVideoLoaderElements {
 		return {
 			root: rootElement,
-			loader: loaderElement?.getElements()
+			loader: resolveElements(loaderElement)
 		};
 	}
 </script>

--- a/src/widgets/scena-video-progress/model/types/index.ts
+++ b/src/widgets/scena-video-progress/model/types/index.ts
@@ -50,7 +50,12 @@ export interface ScenaVideoProgressProps {
 	customStyles: Partial<ScenaVideoProgressComponentStyles>;
 }
 
+/** DOM elements exposed by the video progress component. */
+export interface ScenaVideoProgressElements {
+	root: ScenaProgressLineElements | ScenaProgressCircleElements | null;
+}
+
 /** Component ref for the video progress bar. */
 export interface ScenaVideoProgressRef {
-	getElements: () => ScenaProgressLineElements | ScenaProgressCircleElements | null;
+	getElements: () => ScenaVideoProgressElements;
 }

--- a/src/widgets/scena-video-progress/ui/ScenaVideoProgress.svelte
+++ b/src/widgets/scena-video-progress/ui/ScenaVideoProgress.svelte
@@ -3,7 +3,7 @@
 	import { ComponentSize, ComponentShape } from '@/shared/enums';
 	import { ScenaProgressLine, ScenaProgressCircle } from '@/shared/ui/scena-progress';
 
-	import type { ScenaVideoProgressProps } from '../model';
+	import type { ScenaVideoProgressElements, ScenaVideoProgressProps } from '../model';
 
 	let {
 		id,
@@ -48,8 +48,10 @@
 		previousState = null;
 	}
 
-	export function getElements() {
-		return rootElement?.getElements() ?? null;
+	export function getElements(): ScenaVideoProgressElements {
+		return {
+			root: rootElement?.getElements() ?? null
+		};
 	}
 </script>
 

--- a/src/widgets/scena-video-volume/model/types/index.ts
+++ b/src/widgets/scena-video-volume/model/types/index.ts
@@ -33,13 +33,16 @@ export interface ScenaVideoVolumeProps {
 	customStyles: Partial<ScenaVideoVolumeComponentStyles>;
 }
 
+/** DOM elements exposed by the volume control component. */
+export interface ScenaVideoVolumeElements {
+	root: HTMLDivElement | null;
+	unmuteButton: ScenaButtonElements | null;
+	unmuteIcon: ScenaIconElements | null;
+	muteButton: ScenaButtonElements | null;
+	muteIcon: ScenaIconElements | null;
+}
+
 /** Component ref for the volume control widget. */
 export interface ScenaVideoVolumeRef {
-	getElements: () => {
-		root: HTMLDivElement | null;
-		unmuteButton: ScenaButtonElements | undefined;
-		unmuteIcon: ScenaIconElements | undefined;
-		muteButton: ScenaButtonElements | undefined;
-		muteIcon: ScenaIconElements | undefined;
-	};
+	getElements: () => ScenaVideoVolumeElements;
 }

--- a/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
+++ b/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
@@ -4,9 +4,9 @@
 	import { ComponentSize, ComponentShape } from '@/shared/enums';
 	import { ScenaButton, ScenaButtonShape, ScenaButtonVariant } from '@/shared/ui/scena-button';
 	import { ScenaIcon } from '@/shared/ui/scena-icons';
-	import { formatComponentStyles } from '@/shared/utils';
+	import { formatComponentStyles, resolveElements } from '@/shared/utils';
 
-	import type { ScenaVideoVolumeProps } from '../model';
+	import type { ScenaVideoVolumeElements, ScenaVideoVolumeProps } from '../model';
 
 	let {
 		id,
@@ -42,13 +42,13 @@
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
-	export function getElements() {
+	export function getElements(): ScenaVideoVolumeElements {
 		return {
 			root: rootElement,
-			unmuteButton: unmuteButtonElement?.getElements(),
-			unmuteIcon: unmuteIconElement?.getElements(),
-			muteButton: muteButtonElement?.getElements(),
-			muteIcon: muteIconElement?.getElements()
+			unmuteButton: resolveElements(unmuteButtonElement),
+			unmuteIcon: resolveElements(unmuteIconElement),
+			muteButton: resolveElements(muteButtonElement),
+			muteIcon: resolveElements(muteIconElement)
 		};
 	}
 </script>

--- a/src/widgets/scena-video/model/types/index.ts
+++ b/src/widgets/scena-video/model/types/index.ts
@@ -47,7 +47,7 @@ export interface ScenaVideoSnippets {
 /** Options for creating the video controller. */
 export interface UseVideoControllerOptions {
 	/** Getter that returns the underlying `<video>` DOM element. */
-	getVideoElement: () => HTMLVideoElement;
+	getVideoElement: () => HTMLVideoElement | null;
 	/** Event emitter to broadcast video lifecycle events. */
 	eventEmitter: ScenaEventEmitter;
 }
@@ -55,10 +55,15 @@ export interface UseVideoControllerOptions {
 /** Return value of `useVideoController` — combines reactive data, methods, and callbacks. */
 export type UseVideoControllerReturns = ScenaVideoData & ScenaVideoMethods & ScenaVideoCallbacks;
 
+/** DOM elements exposed by the video widget. */
+export interface ScenaVideoElements {
+	root: HTMLDivElement | null;
+	video: HTMLVideoElement | null;
+}
+
 /** Component ref for the video widget. */
 export interface ScenaVideoRef {
 	/** Video playback controller. */
 	controller: UseVideoControllerReturns;
-	/** Returns references to the root wrapper and video DOM elements. */
-	getElements: () => { root: HTMLDivElement; video: HTMLVideoElement };
+	getElements: () => ScenaVideoElements;
 }

--- a/src/widgets/scena-video/ui/ScenaVideo.svelte
+++ b/src/widgets/scena-video/ui/ScenaVideo.svelte
@@ -6,7 +6,7 @@
 	import { formatComponentStyles } from '@/shared/utils';
 
 	import { useVideoController } from '../model';
-	import type { ScenaVideoProps, ScenaVideoSnippets } from '../model';
+	import type { ScenaVideoElements, ScenaVideoProps, ScenaVideoSnippets } from '../model';
 
 	let {
 		id,
@@ -30,9 +30,9 @@
 
 	const { eventEmitter } = getScenaContext();
 
-	let rootElement: HTMLDivElement;
+	let rootElement: HTMLDivElement | null = $state(null);
 
-	let mediaElement: HTMLVideoElement;
+	let mediaElement: HTMLVideoElement | null = $state(null);
 
 	export const controller = useVideoController({
 		getVideoElement: () => mediaElement,
@@ -57,8 +57,11 @@
 		}
 	});
 
-	export function getElements() {
-		return { root: rootElement, video: mediaElement };
+	export function getElements(): ScenaVideoElements {
+		return {
+			root: rootElement,
+			video: mediaElement
+		};
 	}
 </script>
 


### PR DESCRIPTION
<!--                                                                                                                                                                                                                                                                                                             
  Thanks for sending a PR. Keep the description short — focus on the *why*, the diff already shows the *what*.
  -->                                                                                                                                                                                                                                                                                                              
   
  ## Summary                                                                                                                                                                                                                                                                                                       
                  
Unifies the `getElements()` API and component ref types across all widgets for a consistent public API.                                                                                                                                                                                                                                                                                                                                                                            
                  
  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [ ] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [x] Refactor / internal (no behaviour change)                                                                                                                                                                                                                                                                  
  - [ ] Docs / tooling
                                                                                                                                                                                                                                                                                                                   
  ## Changes      

  - All element bindings typed as `T | null`
  - `resolveElements()` utility for consistent `getElements()` null handling                                                                                                                                                                                                                                                    
  - `ComponentRef<T>` shared type for component instance refs                                                                                                                                                                                                                                    
  - Explicit return type annotations on all `getElements()` functions                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  ## How to test

  1. `npm run validate`                                                                                                                                                                                                                                                                                            
  2. `npm test`
                                                                                                                                                                                                                                                                                                                   
  ## Checklist    

  - [x] `npm run validate` passes locally (lint + typecheck)                                                                                                                                                                                                                                                       
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits                                                                                                                                                                                                                                                                
  - [x] No unrelated refactors mixed in