### PR TITLE
feat(widgets): add customHtml prop for HTML overrides across widget components

### DIFF
--- a/src/shared/styles/components/widgets/_scena-video-controls.scss
+++ b/src/shared/styles/components/widgets/_scena-video-controls.scss
@@ -10,7 +10,7 @@
 	&__play,
 	&__pause {
 		&:hover {
-			transform: var(--rs-video-controls-transform);
+			transform: scale(var(--rs-video-controls-scale));
 		}
 	}
 }

--- a/src/shared/styles/components/widgets/_scena-video-volume.scss
+++ b/src/shared/styles/components/widgets/_scena-video-volume.scss
@@ -20,7 +20,7 @@
 	&__mute,
 	&__unmute {
 		&:hover {
-			transform: var(--rs-video-volume-transform);
+			transform: scale(var(--rs-video-volume-scale));
 		}
 	}
 }

--- a/src/shared/styles/components/widgets/_scena.scss
+++ b/src/shared/styles/components/widgets/_scena.scss
@@ -1,6 +1,7 @@
 .rs {
 	width: fit-content;
 	height: fit-content;
+	font-family: var(--rs-font-family);
 
 	.rs-video-controls,
 	.rs-video-volume {

--- a/src/shared/styles/variables/index.scss
+++ b/src/shared/styles/variables/index.scss
@@ -1,6 +1,10 @@
 @use 'sass:map';
 
 $variables: (
+	'rs': (
+		'font-family': 'inherit'
+	),
+
 	'rs-container': (
 		'offset-x': 24px,
 		'offset-y': 24px,

--- a/src/widgets/scena-controls/model/types/index.ts
+++ b/src/widgets/scena-controls/model/types/index.ts
@@ -17,6 +17,11 @@ export interface ScenaCloseButtonComponentStyles {
 	cross: ComponentStyles;
 }
 
+/** Custom HTML override for the close button. */
+export interface ScenaCloseButtonComponentHtml {
+	button: string;
+}
+
 /** Configuration props for the close button widget. */
 export interface ScenaCloseButtonProps {
 	id: string;
@@ -25,6 +30,7 @@ export interface ScenaCloseButtonProps {
 	aria: Partial<ComponentAriaProps>;
 	customClasses: Partial<ScenaCloseButtonComponentClasses>;
 	customStyles: Partial<ScenaCloseButtonComponentStyles>;
+	customHtml: Partial<ScenaCloseButtonComponentHtml>;
 	onClick: (event: Event) => void;
 }
 

--- a/src/widgets/scena-controls/ui/ScenaCloseButton.svelte
+++ b/src/widgets/scena-controls/ui/ScenaCloseButton.svelte
@@ -16,6 +16,7 @@
 		aria = { ariaLabel: 'Close' },
 		customClasses,
 		customStyles,
+		customHtml,
 		onClick
 	}: Partial<ScenaCloseButtonProps> = $props();
 
@@ -57,23 +58,28 @@
 </script>
 
 <div {id} bind:this={rootElement} class={rootClasses} style={rootStyles}>
-	<ScenaButton
-		bind:this={buttonElement}
-		{aria}
-		autosize
-		shape={ScenaButtonShape.CIRCLE}
-		variant={ScenaButtonVariant.FILLED}
-		customClasses={{ root: customClasses?.button }}
-		customStyles={{ root: customStyles?.button }}
-		onclick={onCloseButtonClick}
-	>
-		<ScenaIcon
-			bind:this={crossElement}
-			{size}
-			customClasses={{ root: customClasses?.cross }}
-			customStyles={{ root: customStyles?.cross }}
+	{#if customHtml?.button}
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html customHtml.button}
+	{:else}
+		<ScenaButton
+			bind:this={buttonElement}
+			{aria}
+			autosize
+			shape={ScenaButtonShape.CIRCLE}
+			variant={ScenaButtonVariant.FILLED}
+			customClasses={{ root: customClasses?.button }}
+			customStyles={{ root: customStyles?.button }}
+			onclick={onCloseButtonClick}
 		>
-			<IconCross />
-		</ScenaIcon>
-	</ScenaButton>
+			<ScenaIcon
+				bind:this={crossElement}
+				{size}
+				customClasses={{ root: customClasses?.cross }}
+				customStyles={{ root: customStyles?.cross }}
+			>
+				<IconCross />
+			</ScenaIcon>
+		</ScenaButton>
+	{/if}
 </div>

--- a/src/widgets/scena-cta/model/types/index.ts
+++ b/src/widgets/scena-cta/model/types/index.ts
@@ -16,6 +16,11 @@ export interface ScenaCtaButtonComponentStyles {
 	button: ComponentStyles;
 }
 
+/** Custom HTML override for the CTA button. */
+export interface ScenaCtaButtonComponentHtml {
+	button: string;
+}
+
 /** Adaptive display settings for the CTA button across screen sizes. */
 export interface ScenaCtaButtonAdaptive {
 	sizes: ComponentSize[];
@@ -32,6 +37,7 @@ export interface ScenaCtaButtonProps {
 	aria: Partial<ComponentAriaProps>;
 	customClasses: Partial<ScenaCtaButtonComponentClasses>;
 	customStyles: Partial<ScenaCtaButtonComponentStyles>;
+	customHtml: Partial<ScenaCtaButtonComponentHtml>;
 	onClick: (event: Event) => void;
 }
 

--- a/src/widgets/scena-cta/ui/ScenaCtaButton.svelte
+++ b/src/widgets/scena-cta/ui/ScenaCtaButton.svelte
@@ -23,6 +23,7 @@
 		aria,
 		customClasses,
 		customStyles,
+		customHtml,
 		onClick
 	}: Partial<ScenaCtaButtonProps> = $props();
 
@@ -61,15 +62,20 @@
 </script>
 
 <div {id} bind:this={rootElement} class={rootClasses} style={rootStyles}>
-	<ScenaButton
-		bind:this={buttonElement}
-		{size}
-		{aria}
-		shape={ScenaButtonShape.RECTANGLE}
-		customClasses={{ root: customClasses?.button }}
-		customStyles={{ root: customStyles?.button }}
-		onclick={onCtaButtonClick}
-	>
-		{text}
-	</ScenaButton>
+	{#if customHtml?.button}
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html customHtml.button}
+	{:else}
+		<ScenaButton
+			bind:this={buttonElement}
+			{size}
+			{aria}
+			shape={ScenaButtonShape.RECTANGLE}
+			customClasses={{ root: customClasses?.button }}
+			customStyles={{ root: customStyles?.button }}
+			onclick={onCtaButtonClick}
+		>
+			{text}
+		</ScenaButton>
+	{/if}
 </div>

--- a/src/widgets/scena-video-controls/model/types/index.ts
+++ b/src/widgets/scena-video-controls/model/types/index.ts
@@ -17,6 +17,12 @@ export interface ScenaVideoControlsComponentStyles {
 	pause: ComponentStyles;
 }
 
+/** Custom HTML overrides for the video play/pause controls. */
+export interface ScenaVideoControlsComponentHtml {
+	play: string;
+	pause: string;
+}
+
 /** Per-button ARIA overrides for video controls. */
 export interface ScenaVideoControlsComponentAria {
 	play: Partial<ComponentAriaProps>;
@@ -30,6 +36,7 @@ export interface ScenaVideoControlsProps {
 	aria: Partial<ScenaVideoControlsComponentAria>;
 	customClasses: Partial<ScenaVideoControlsComponentClasses>;
 	customStyles: Partial<ScenaVideoControlsComponentStyles>;
+	customHtml: Partial<ScenaVideoControlsComponentHtml>;
 }
 
 /** DOM elements exposed by the video controls component. */

--- a/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
+++ b/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
@@ -16,7 +16,8 @@
 			pause: { ariaLabel: 'Pause' }
 		},
 		customClasses,
-		customStyles
+		customStyles,
+		customHtml
 	}: Partial<ScenaVideoControlsProps> = $props();
 
 	const scenaVideoContext = getScenaVideoContext();
@@ -64,45 +65,55 @@
 			{/if}
 		</span>
 		{#if isShownPause}
-			<ScenaButton
-				bind:this={pauseButtonElement}
-				{size}
-				shape={ScenaButtonShape.CIRCLE}
-				variant={ScenaButtonVariant.TEXT}
-				aria={aria.pause}
-				customClasses={{ root: 'rs-video-controls__pause' }}
-				onclick={scenaVideoContext.pause}
-			>
-				<ScenaIcon
-					bind:this={pauseIconElement}
+			{#if customHtml?.pause}
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html customHtml.pause}
+			{:else}
+				<ScenaButton
+					bind:this={pauseButtonElement}
 					{size}
-					viewBox="0 0 32 32"
-					customClasses={{ root: customClasses?.pause }}
-					customStyles={{ root: customStyles?.pause }}
+					shape={ScenaButtonShape.CIRCLE}
+					variant={ScenaButtonVariant.TEXT}
+					aria={aria.pause}
+					customClasses={{ root: 'rs-video-controls__pause' }}
+					onclick={scenaVideoContext.pause}
 				>
-					<IconPause />
-				</ScenaIcon>
-			</ScenaButton>
+					<ScenaIcon
+						bind:this={pauseIconElement}
+						{size}
+						viewBox="0 0 32 32"
+						customClasses={{ root: customClasses?.pause }}
+						customStyles={{ root: customStyles?.pause }}
+					>
+						<IconPause />
+					</ScenaIcon>
+				</ScenaButton>
+			{/if}
 		{:else if isShownPlay}
-			<ScenaButton
-				bind:this={playButtonElement}
-				{size}
-				shape={ScenaButtonShape.CIRCLE}
-				variant={ScenaButtonVariant.TEXT}
-				aria={aria.play}
-				customClasses={{ root: 'rs-video-controls__play' }}
-				onclick={scenaVideoContext.play}
-			>
-				<ScenaIcon
-					bind:this={playIconElement}
+			{#if customHtml?.play}
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html customHtml.play}
+			{:else}
+				<ScenaButton
+					bind:this={playButtonElement}
 					{size}
-					viewBox="0 0 32 32"
-					customClasses={{ root: customClasses?.play }}
-					customStyles={{ root: customStyles?.play }}
+					shape={ScenaButtonShape.CIRCLE}
+					variant={ScenaButtonVariant.TEXT}
+					aria={aria.play}
+					customClasses={{ root: 'rs-video-controls__play' }}
+					onclick={scenaVideoContext.play}
 				>
-					<IconPlay />
-				</ScenaIcon>
-			</ScenaButton>
+					<ScenaIcon
+						bind:this={playIconElement}
+						{size}
+						viewBox="0 0 32 32"
+						customClasses={{ root: customClasses?.play }}
+						customStyles={{ root: customStyles?.play }}
+					>
+						<IconPlay />
+					</ScenaIcon>
+				</ScenaButton>
+			{/if}
 		{/if}
 	</div>
 {/if}

--- a/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
+++ b/src/widgets/scena-video-controls/ui/ScenaVideoControls.svelte
@@ -70,6 +70,7 @@
 				shape={ScenaButtonShape.CIRCLE}
 				variant={ScenaButtonVariant.TEXT}
 				aria={aria.pause}
+				customClasses={{ root: 'rs-video-controls__pause' }}
 				onclick={scenaVideoContext.pause}
 			>
 				<ScenaIcon
@@ -89,6 +90,7 @@
 				shape={ScenaButtonShape.CIRCLE}
 				variant={ScenaButtonVariant.TEXT}
 				aria={aria.play}
+				customClasses={{ root: 'rs-video-controls__play' }}
 				onclick={scenaVideoContext.play}
 			>
 				<ScenaIcon

--- a/src/widgets/scena-video-loader/model/types/index.ts
+++ b/src/widgets/scena-video-loader/model/types/index.ts
@@ -14,12 +14,18 @@ export interface ScenaVideoLoaderComponentStyles {
 	loader: ComponentStyles;
 }
 
+/** Custom HTML override for the video loader. */
+export interface ScenaVideoLoaderComponentHtml {
+	loader: string;
+}
+
 /** Configuration props for the video buffering/loading indicator. */
 export interface ScenaVideoLoaderProps {
 	id: string;
 	size: ComponentSize;
 	customClasses: Partial<ScenaVideoLoaderComponentClasses>;
 	customStyles: Partial<ScenaVideoLoaderComponentStyles>;
+	customHtml: Partial<ScenaVideoLoaderComponentHtml>;
 }
 
 /** DOM elements exposed by the video loader component. */

--- a/src/widgets/scena-video-loader/ui/ScenaVideoLoader.svelte
+++ b/src/widgets/scena-video-loader/ui/ScenaVideoLoader.svelte
@@ -10,7 +10,8 @@
 		id,
 		size = ComponentSize.MD,
 		customClasses,
-		customStyles
+		customStyles,
+		customHtml
 	}: Partial<ScenaVideoLoaderProps> = $props();
 
 	const scenaVideoContext = getScenaVideoContext();
@@ -33,11 +34,16 @@
 
 <div {id} bind:this={rootElement} class={rootClasses} style={rootStyles}>
 	{#if scenaVideoContext.state === ScenaVideoState.LOADING}
-		<ScenaLoader
-			bind:this={loaderElement}
-			{size}
-			customClasses={{ root: customClasses?.loader }}
-			customStyles={{ root: customStyles?.loader }}
-		/>
+		{#if customHtml?.loader}
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+			{@html customHtml.loader}
+		{:else}
+			<ScenaLoader
+				bind:this={loaderElement}
+				{size}
+				customClasses={{ root: customClasses?.loader }}
+				customStyles={{ root: customStyles?.loader }}
+			/>
+		{/if}
 	{/if}
 </div>

--- a/src/widgets/scena-video-volume/model/types/index.ts
+++ b/src/widgets/scena-video-volume/model/types/index.ts
@@ -17,6 +17,12 @@ export interface ScenaVideoVolumeComponentStyles {
 	unmute: ComponentStyles;
 }
 
+/** Custom HTML overrides for the volume mute/unmute controls. */
+export interface ScenaVideoVolumeComponentHtml {
+	mute: string;
+	unmute: string;
+}
+
 /** Per-button ARIA overrides for volume controls. */
 export interface ScenaVideoVolumeComponentAria {
 	mute: Partial<ComponentAriaProps>;
@@ -31,6 +37,7 @@ export interface ScenaVideoVolumeProps {
 	aria: Partial<ScenaVideoVolumeComponentAria>;
 	customClasses: Partial<ScenaVideoVolumeComponentClasses>;
 	customStyles: Partial<ScenaVideoVolumeComponentStyles>;
+	customHtml: Partial<ScenaVideoVolumeComponentHtml>;
 }
 
 /** DOM elements exposed by the volume control component. */

--- a/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
+++ b/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
@@ -69,6 +69,7 @@
 				shape={ScenaButtonShape.CIRCLE}
 				variant={ScenaButtonVariant.TEXT}
 				aria={aria.unmute}
+				customClasses={{ root: 'rs-video-volume__unmute' }}
 				onclick={scenaVideoContext.unmute}
 			>
 				<ScenaIcon
@@ -87,6 +88,7 @@
 				shape={ScenaButtonShape.CIRCLE}
 				variant={ScenaButtonVariant.TEXT}
 				aria={aria.mute}
+				customClasses={{ root: 'rs-video-volume__mute' }}
 				onclick={scenaVideoContext.mute}
 			>
 				<ScenaIcon

--- a/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
+++ b/src/widgets/scena-video-volume/ui/ScenaVideoVolume.svelte
@@ -17,7 +17,8 @@
 			unmute: { ariaLabel: 'Unmute' }
 		},
 		customClasses,
-		customStyles
+		customStyles,
+		customHtml
 	}: Partial<ScenaVideoVolumeProps> = $props();
 
 	const scenaVideoContext = getScenaVideoContext();
@@ -63,24 +64,32 @@
 			{/if}
 		</span>
 		{#if scenaVideoContext.isMuted}
-			<ScenaButton
-				bind:this={unmuteButtonElement}
-				{size}
-				shape={ScenaButtonShape.CIRCLE}
-				variant={ScenaButtonVariant.TEXT}
-				aria={aria.unmute}
-				customClasses={{ root: 'rs-video-volume__unmute' }}
-				onclick={scenaVideoContext.unmute}
-			>
-				<ScenaIcon
-					bind:this={unmuteIconElement}
+			{#if customHtml?.unmute}
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				{@html customHtml.unmute}
+			{:else}
+				<ScenaButton
+					bind:this={unmuteButtonElement}
 					{size}
-					customClasses={{ root: customClasses?.unmute }}
-					customStyles={{ root: customStyles?.unmute }}
+					shape={ScenaButtonShape.CIRCLE}
+					variant={ScenaButtonVariant.TEXT}
+					aria={aria.unmute}
+					customClasses={{ root: 'rs-video-volume__unmute' }}
+					onclick={scenaVideoContext.unmute}
 				>
-					<IconUnmute />
-				</ScenaIcon>
-			</ScenaButton>
+					<ScenaIcon
+						bind:this={unmuteIconElement}
+						{size}
+						customClasses={{ root: customClasses?.unmute }}
+						customStyles={{ root: customStyles?.unmute }}
+					>
+						<IconUnmute />
+					</ScenaIcon>
+				</ScenaButton>
+			{/if}
+		{:else if customHtml?.mute}
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+			{@html customHtml.mute}
 		{:else}
 			<ScenaButton
 				bind:this={muteButtonElement}


### PR DESCRIPTION
<!--
  Thanks for sending a PR. Keep the description short — focus on the *why*, the diff already shows the *what*.
  -->

  ## Summary
  
  Adds `customHtml` prop to widget components, allowing consumers to replace default buttons and the loader with arbitrary HTML strings via `{@html}`.

  Closes #
  
  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [x] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes
  
  - Added `customHtml` prop and `*ComponentHtml` interface to all interactive widgets
  - When `customHtml` is provided, the default component is replaced with raw HTML via `{@html}`
  - Fixed `--rs-video-controls-transform` / `--rs-video-volume-transform` → `scale(var(--rs-video-*-scale))` in SCSS

  ## How to test

  1. Pass `customHtml` to any widget prop, e.g.:
     ```ts
     videoControls: {
       customHtml: {
         play: '<button data-rs-action="play">▶</button>',
         pause: '<button data-rs-action="pause">⏸</button>'
       }
     }
     ```
  2. Verify the default button is replaced by the custom HTML in the DOM
  3. Verify default behaviour is intact when `customHtml` is omitted

  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in