### PR TITLE
refactor: rename march to mrq for matchMedia variable

### DIFF
--- a/src/app/entrypoint/model/lib/useScenaResponsive.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScenaResponsive.svelte.ts
@@ -91,15 +91,15 @@ export default function useScenaResponsive(
 		/** Register matchMedia listeners for each breakpoint */
 		for (const breakpoint of sortedBreakpoints) {
 			/** Create media query for current breakpoint */
-			const march = window.matchMedia(`(max-width: ${breakpoint}px)`);
+			const mrq = window.matchMedia(`(max-width: ${breakpoint}px)`);
 
 			/** Handler that recalculates active breakpoint */
 			const handler = () => update(sortedBreakpoints, responsiveConfig);
 
-			march.addEventListener('change', handler);
+			mrq.addEventListener('change', handler);
 
 			cleanups.push(() => {
-				march.removeEventListener('change', handler);
+				mrq.removeEventListener('change', handler);
 			});
 		}
 


### PR DESCRIPTION
## Summary

  Renames local variable `march` → `mrq` (matchMedia query) for clarity.

  ## Type of change
  
  - [x] Refactor / internal (no behaviour change)

  ## Changes
  
  - Renamed `march` to `mrq` in `useScenaResponsive`

  ## How to test

  1. Run the app and verify responsive breakpoints still work as expected

  ## Checklist
  
  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in
