### PR TITLE
fix(styles): propagate pointer-events: none to children in --hidden modifier

### DIFF
--- a/src/shared/styles/components/widgets/_scena-container.scss
+++ b/src/shared/styles/components/widgets/_scena-container.scss
@@ -75,5 +75,9 @@
 	&--hidden {
 		visibility: hidden;
 		pointer-events: none;
+
+		* {
+			pointer-events: none;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

  Propagates `pointer-events: none` to all children of `.scena-container--hidden` to prevent child elements from intercepting pointer events when the container is hidden.

  ## Type of change
  
  - [x] Bug fix (non-breaking)

  ## Changes
  
  - `.scena-container--hidden *` now inherits `pointer-events: none`

  ## How to test

  1. Render a hidden container with interactive children (buttons, links)
  2. Verify clicks/hovers on children no longer fire

  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in
