### PR TITLE
refactor: rename march to mql for matchMedia variable

### DIFF
--- a/src/app/entrypoint/model/lib/useScenaResponsive.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScenaResponsive.svelte.ts
@@ -91,15 +91,15 @@ export default function useScenaResponsive(
 		/** Register matchMedia listeners for each breakpoint */
 		for (const breakpoint of sortedBreakpoints) {
 			/** Create media query for current breakpoint */
-			const march = window.matchMedia(`(max-width: ${breakpoint}px)`);
+			const mql = window.matchMedia(`(max-width: ${breakpoint}px)`);
 
 			/** Handler that recalculates active breakpoint */
 			const handler = () => update(sortedBreakpoints, responsiveConfig);
 
-			march.addEventListener('change', handler);
+			mql.addEventListener('change', handler);
 
 			cleanups.push(() => {
-				march.removeEventListener('change', handler);
+				mql.removeEventListener('change', handler);
 			});
 		}
 


### PR DESCRIPTION
## Summary

  Renames local variable `march` → `mql` (matchMedia query) for clarity.

  ## Type of change
  
  - [x] Refactor / internal (no behaviour change)

  ## Changes
  
  - Renamed `march` to `mql` in `useScenaResponsive`

  ## How to test

  1. Run the app and verify responsive breakpoints still work as expected

  ## Checklist
  
  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in
