### PR TITLE
feat: add ScenaError, assertBrowser and fix SSR-unsafe mount target

### DIFF
--- a/src/app/entrypoint/model/lib/useScena.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScena.svelte.ts
@@ -1,6 +1,7 @@
 import { mount as _mount, unmount as _unmount } from 'svelte';
 
 import { ScenaEvent, useEventEmitter } from '@/entities/event';
+import { assertBrowser } from '@/shared/utils/environment';
 
 import { Scena } from '../../ui';
 
@@ -41,10 +42,12 @@ export default function useScena(): UseScenaReturns {
 	 * @param scenaTarget - DOM element or ShadowRoot to mount into. Defaults to `document.body`.
 	 * @returns A promise that resolves with the {@link ScenaInstance} handle.
 	 */
-	function mount(
-		scenaConfig: ScenaConfig,
-		scenaTarget: ScenaTarget = document.body
-	): Promise<ScenaInstance> {
+	function mount(scenaConfig: ScenaConfig, scenaTarget?: ScenaTarget): Promise<ScenaInstance> {
+		assertBrowser('mount');
+
+		/** Safe to read `document.body` here — `assertBrowser` above guarantees DOM is available. */
+		const target = scenaTarget ?? document.body;
+
 		const promise = new Promise<ScenaInstance>((resolve) => {
 			const config = useScenaConfig(scenaConfig);
 
@@ -62,7 +65,7 @@ export default function useScena(): UseScenaReturns {
 			responsive.apply();
 
 			const component: Scena = _mount(Scena, {
-				target: scenaTarget,
+				target,
 				props: {
 					get config() {
 						return configOverrides.resolved;

--- a/src/shared/utils/environment/assert-browser/index.ts
+++ b/src/shared/utils/environment/assert-browser/index.ts
@@ -1,0 +1,14 @@
+import { ScenaError } from '../../errors';
+import { isBrowser } from '../is-browser';
+
+/**
+ * Throws a {@link ScenaError} when called outside a browser environment.
+ *
+ * @param method - The calling method name, included in the error message.
+ * @throws {ScenaError} When `isBrowser` is `false`.
+ */
+export function assertBrowser(method: string): void {
+	if (!isBrowser) {
+		throw new ScenaError(`${method}() requires a browser environment`);
+	}
+}

--- a/src/shared/utils/environment/index.ts
+++ b/src/shared/utils/environment/index.ts
@@ -1,1 +1,2 @@
 export { isBrowser } from './is-browser';
+export { assertBrowser } from './assert-browser';

--- a/src/shared/utils/errors/index.ts
+++ b/src/shared/utils/errors/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Base error class for all scena runtime errors.
+ *
+ * Using a named subclass makes scena errors easy to identify
+ * in stack traces and `instanceof` checks.
+ */
+export class ScenaError extends Error {
+	override readonly name = 'ScenaError';
+
+	constructor(message: string) {
+		super(message);
+	}
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,3 +1,4 @@
 export { formatComponentStyleProperty, formatComponentStyles, resolveElements } from './components';
-export { isBrowser } from './environment';
+export { isBrowser, assertBrowser } from './environment';
+export { ScenaError } from './errors';
 export { deepClone, deepMerge, pick } from './objects';


### PR DESCRIPTION
 ## Summary
  
  <!-- One or two sentences. Link the issue this PR closes, if any. -->

  Adds `ScenaError` and `assertBrowser` utilities to `shared/utils`, and fixes an SSR crash caused by `document.body` being evaluated as a default parameter in `mount()`.
  
  ## Type of change

  <!-- Mark the one that applies. -->

  - [x] Bug fix (non-breaking)
  - [x] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes

  <!-- Bullet list of user-visible changes. Skip if trivial. -->
  
  - Added `ScenaError` class (`shared/utils/errors`)
  - Added `assertBrowser(method)` utility (`shared/utils/environment/assert-browser`)
  - `mount()` now throws a `ScenaError` in non-browser environments instead of crashing on `document.body`
  - `scenaTarget` parameter changed from `= document.body` to optional `?` — behaviour unchanged in browser

  ## How to test

  <!-- Steps to verify the change works. A failing unit test or reproduction script counts. -->

  1. Call `useScena().mount(config)` in an SSR environment (e.g. Node.js) — expect a `ScenaError` with message `mount() requires a browser environment`
  2. Call without `scenaTarget` in a browser — widget mounts to `document.body` as before

  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in
