### PR TITLE
feat(event): add once() method to ScenaEventEmitter

### DIFF
--- a/src/entities/event/model/lib/__tests__/useEventEmitter.test.ts
+++ b/src/entities/event/model/lib/__tests__/useEventEmitter.test.ts
@@ -33,6 +33,27 @@ describe('useEventEmitter', () => {
 			expect(second).toHaveBeenCalledOnce();
 		});
 
+		it('should call once handler only on first emit', () => {
+			const emitter = useEventEmitter();
+			const handler = vi.fn();
+
+			emitter.once(ScenaEvent.ON_VIDEO_PLAY, handler);
+			emitter.emit(ScenaEvent.ON_VIDEO_PLAY);
+			emitter.emit(ScenaEvent.ON_VIDEO_PLAY);
+
+			expect(handler).toHaveBeenCalledOnce();
+		});
+
+		it('should call once handler with emitted data', () => {
+			const emitter = useEventEmitter();
+			const handler = vi.fn();
+
+			emitter.once(ScenaEvent.ON_VIDEO_PLAY, handler);
+			emitter.emit(ScenaEvent.ON_VIDEO_PLAY, { state: 'playing' });
+
+			expect(handler).toHaveBeenCalledWith({ state: 'playing' });
+		});
+
 		it('should unsubscribe handler with off', () => {
 			const emitter = useEventEmitter();
 			const handler = vi.fn();
@@ -150,6 +171,20 @@ describe('useEventEmitter', () => {
 			emitter.emit(ScenaEvent.ON_VIDEO_PLAY);
 
 			expect(handler).toHaveBeenCalledOnce();
+		});
+
+		it('should not affect other handlers when once unsubscribes', () => {
+			const emitter = useEventEmitter();
+			const onceHandler = vi.fn();
+			const persistentHandler = vi.fn();
+
+			emitter.once(ScenaEvent.ON_VIDEO_PLAY, onceHandler);
+			emitter.on(ScenaEvent.ON_VIDEO_PLAY, persistentHandler);
+			emitter.emit(ScenaEvent.ON_VIDEO_PLAY);
+			emitter.emit(ScenaEvent.ON_VIDEO_PLAY);
+
+			expect(onceHandler).toHaveBeenCalledOnce();
+			expect(persistentHandler).toHaveBeenCalledTimes(2);
 		});
 
 		it('should create independent instances', () => {

--- a/src/entities/event/model/lib/useEventEmitter.ts
+++ b/src/entities/event/model/lib/useEventEmitter.ts
@@ -13,6 +13,15 @@ export function useEventEmitter(): ScenaEventEmitter {
 		events.get(eventName)?.add(handler);
 	}
 
+	function once(eventName: ScenaEvent, handler: ScenaEventHandler) {
+		const wrapper: ScenaEventHandler = (data) => {
+			off(eventName, wrapper);
+			handler(data);
+		};
+
+		on(eventName, wrapper);
+	}
+
 	function off(eventName: ScenaEvent, handler: ScenaEventHandler) {
 		const handlers = events.get(eventName);
 
@@ -37,5 +46,5 @@ export function useEventEmitter(): ScenaEventEmitter {
 		events.clear();
 	}
 
-	return { on, off, emit, remove, clear };
+	return { on, once, off, emit, remove, clear };
 }

--- a/src/entities/event/model/types/index.ts
+++ b/src/entities/event/model/types/index.ts
@@ -10,6 +10,8 @@ export type ScenaEventMap<T = unknown> = Map<ScenaEvent, Set<ScenaEventHandler<T
 export interface ScenaEventEmitter {
 	/** Subscribe a handler to an event. */
 	on(eventName: ScenaEvent, handler: ScenaEventHandler): void;
+	/** Subscribe a handler to an event; auto-unsubscribes after first call. */
+	once(eventName: ScenaEvent, handler: ScenaEventHandler): void;
 	/** Unsubscribe a specific handler from an event. */
 	off(eventName: ScenaEvent, handler: ScenaEventHandler): void;
 	/** Emit an event, calling all subscribed handlers with optional data. */


### PR DESCRIPTION
<!--
  Thanks for sending a PR. Keep the description short — focus on the *why*, the diff already shows the *what*.
  -->

  ## Summary

  Adds `once()` to `ScenaEventEmitter` — a one-time subscription that auto-unsubscribes after the first call.
  
  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [x] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes
  
  - `ScenaEventEmitter` interface gains `once(eventName, handler)`
  - `useEventEmitter` implements `once` via a self-removing wrapper

  ## How to test

  1. Subscribe with `once`, emit twice — handler fires exactly once.

  ## Checklist
  
  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in