### PR TITLE
refactor(playground): mute video on ON_CTA_CLICK

### DIFF
--- a/playground/src/App.svelte
+++ b/playground/src/App.svelte
@@ -31,6 +31,7 @@
 		});
 
 		instance.api.events.on(ScenaEvent.ON_CTA_CLICK, () => {
+			instance.api.controller.mute();
 			instance.preview.start();
 		});
 


### PR DESCRIPTION
## Summary

  Mutes the video when `ON_CTA_CLICK` fires in the playground, so the preview starts silently.

  ## Type of change
  
  - [ ] Bug fix (non-breaking)
  - [ ] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [x] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes
  
  - Call `controller.mute()` before `preview.start()` on `ON_CTA_CLICK` in the playground app

  ## How to test

  1. Open the playground
  2. Trigger a CTA click
  3. Confirm the video preview starts muted (no audio)
  
  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in
