### PR TITLE
feat: focus management for preview mode

### DIFF
--- a/src/app/entrypoint/model/lib/__tests__/useScenaPreview.test.ts
+++ b/src/app/entrypoint/model/lib/__tests__/useScenaPreview.test.ts
@@ -198,6 +198,7 @@ describe('useScenaPreview', () => {
 			preview.api.start();
 
 			expect(overrides.resolved.videoContainer).toEqual({
+				isInteractive: true,
 				customClasses: {
 					root: [undefined, 'rs-video-container--preview']
 				}
@@ -225,6 +226,7 @@ describe('useScenaPreview', () => {
 			preview.api.start();
 
 			expect(overrides.resolved.videoContainer).toEqual({
+				isInteractive: true,
 				customClasses: {
 					root: ['existing', 'rs-video-container--preview']
 				}

--- a/src/app/entrypoint/model/lib/useScena.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScena.svelte.ts
@@ -91,6 +91,41 @@ export default function useScena(): UseScenaReturns {
 								if (!preview.api.isKeepMuteOnExpand) {
 									scena.api.controller.unmute();
 								}
+
+								/**
+								 * Hands focus over to the expanded widget. Deferring one frame
+								 * lets the DOM drop `inert` from the container content first.
+								 * The first focusable control is queried instead of a specific
+								 * component because any of them can be disabled via config.
+								 */
+								requestAnimationFrame(() => {
+									const { videoProgress, videoControls, videoVolume } = scena.api.components;
+
+									const controls = videoControls?.getElements();
+
+									const volume = videoVolume?.getElements();
+
+									const focusTarget =
+										videoProgress?.getElements().root?.root ??
+										controls?.pauseButton?.root ??
+										controls?.playButton?.root ??
+										volume?.muteButton?.root ??
+										volume?.unmuteButton?.root;
+
+									focusTarget?.focus();
+								});
+							}
+						});
+
+						scena.api.events.on(ScenaEvent.ON_PREVIEW_START, () => {
+							const containerRoot = scena.api.components.videoContainer?.getElements()?.root;
+
+							/**
+							 * Collapsing makes the content inert, which would silently drop
+							 * focus to `<body>` — return it to the container button instead.
+							 */
+							if (containerRoot?.contains(document.activeElement)) {
+								requestAnimationFrame(() => containerRoot.focus());
 							}
 						});
 

--- a/src/app/entrypoint/model/lib/useScenaPreview.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScenaPreview.svelte.ts
@@ -45,6 +45,7 @@ export default function useScenaPreview(
 		configOverrides.set(OverrideLayer.PREVIEW, () => ({
 			...config.getConfig().preview,
 			videoContainer: {
+				isInteractive: true,
 				customClasses: {
 					root: [
 						config.getConfig().videoContainer?.customClasses?.root,

--- a/src/shared/styles/components/shared/_scena-progress.scss
+++ b/src/shared/styles/components/shared/_scena-progress.scss
@@ -7,10 +7,6 @@
 	pointer-events: auto;
 	z-index: 10;
 
-	&:focus {
-		outline: none;
-	}
-
 	.rs-progress__track {
 		position: relative;
 		width: 100%;

--- a/src/shared/styles/components/widgets/_scena.scss
+++ b/src/shared/styles/components/widgets/_scena.scss
@@ -8,7 +8,8 @@
 		opacity: 0;
 	}
 
-	&:hover {
+	&:hover,
+	&:focus-within {
 		.rs-video-controls,
 		.rs-video-volume {
 			opacity: 1;

--- a/src/shared/ui/scena-progress/model/lib/useProgressCircle.svelte.ts
+++ b/src/shared/ui/scena-progress/model/lib/useProgressCircle.svelte.ts
@@ -11,6 +11,7 @@ export default function useProgressCircle({
 	getSize,
 	getBuffer,
 	getProgress,
+	getStep,
 	getCustomThickness,
 	onSeek,
 	onSeekStart,
@@ -74,6 +75,45 @@ export default function useProgressCircle({
 	function onMouseLeaveRootElement() {
 		if (isDragging) return;
 		isFocused = false;
+	}
+
+	function onFocus() {
+		isFocused = true;
+	}
+
+	function onBlur() {
+		if (isDragging) return;
+		isFocused = false;
+	}
+
+	function onKeyDown(event: KeyboardEvent): void {
+		const current = getProgress();
+
+		let next: number | null = null;
+
+		switch (event.key) {
+			case 'ArrowLeft':
+			case 'ArrowDown':
+				next = Math.max(0, current - getStep());
+				break;
+			case 'ArrowRight':
+			case 'ArrowUp':
+				next = Math.min(1, current + getStep());
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = 1;
+				break;
+		}
+
+		if (next === null) return;
+
+		event.preventDefault();
+		onSeekStart?.(event);
+		onSeek?.(next, event);
+		onSeekEnd?.(event);
 	}
 
 	function onTrackClick(event: MouseEvent): void {
@@ -195,7 +235,10 @@ export default function useProgressCircle({
 			onpointerup: stopDragging,
 			onpointercancel: stopDragging,
 			onmouseenter: onMouseEnterRootElement,
-			onmouseleave: onMouseLeaveRootElement
+			onmouseleave: onMouseLeaveRootElement,
+			onfocus: onFocus,
+			onblur: onBlur,
+			onkeydown: onKeyDown
 		}
 	};
 }

--- a/src/shared/ui/scena-progress/model/lib/useProgressLine.svelte.ts
+++ b/src/shared/ui/scena-progress/model/lib/useProgressLine.svelte.ts
@@ -3,6 +3,7 @@ import type { UseProgressLineEvents, UseProgressLineProps, UseProgressLineReturn
 export default function useProgressLine({
 	getRootElement,
 	getSize,
+	getStep,
 	getProgress,
 	getCustomThickness,
 	onSeek,
@@ -49,6 +50,45 @@ export default function useProgressLine({
 	function onMouseLeaveRootElement() {
 		if (isDragging) return;
 		isFocused = false;
+	}
+
+	function onFocus() {
+		isFocused = true;
+	}
+
+	function onBlur() {
+		if (isDragging) return;
+		isFocused = false;
+	}
+
+	function onKeyDown(event: KeyboardEvent): void {
+		const current = getProgress();
+
+		let next: number | null = null;
+
+		switch (event.key) {
+			case 'ArrowLeft':
+			case 'ArrowDown':
+				next = Math.max(0, current - getStep());
+				break;
+			case 'ArrowRight':
+			case 'ArrowUp':
+				next = Math.min(1, current + getStep());
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = 1;
+				break;
+		}
+
+		if (next === null) return;
+
+		event.preventDefault();
+		onSeekStart?.(event);
+		onSeek?.(next, event);
+		onSeekEnd?.(event);
 	}
 
 	function capturePointer(event: PointerEvent): void {
@@ -154,7 +194,10 @@ export default function useProgressLine({
 			onpointerdown: onPointerDown,
 			onpointercancel: onPointerCancel,
 			onmouseenter: onMouseEnterRootElement,
-			onmouseleave: onMouseLeaveRootElement
+			onmouseleave: onMouseLeaveRootElement,
+			onfocus: onFocus,
+			onblur: onBlur,
+			onkeydown: onKeyDown
 		}
 	};
 }

--- a/src/shared/ui/scena-progress/model/types/index.ts
+++ b/src/shared/ui/scena-progress/model/types/index.ts
@@ -30,9 +30,11 @@ export interface ScenaProgressCircleComponentStyles {
 export interface ScenaProgressCircleProps {
 	id: string;
 	size: ComponentSize;
-	buffer: number;
+	step: number;
 	progress: number;
+	buffer: number;
 	hasBuffer: boolean;
+	valueText: string;
 	aria: Partial<ComponentAriaProps>;
 	customThickness: Partial<ScenaProgressComponentThickness>;
 	customClasses: Partial<ScenaProgressCircleComponentClasses>;
@@ -66,9 +68,11 @@ export interface ScenaProgressLineComponentStyles {
 export interface ScenaProgressLineProps {
 	id: string;
 	size: ComponentSize;
-	buffer: number;
+	step: number;
 	progress: number;
+	buffer: number;
 	hasBuffer: boolean;
+	valueText: string;
 	customThickness: Partial<ScenaProgressComponentThickness>;
 	customClasses: Partial<ScenaProgressLineComponentClasses>;
 	customStyles: Partial<ScenaProgressLineComponentStyles>;
@@ -90,6 +94,9 @@ export interface UseProgressLineReturnEvents {
 	onpointercancel: (event: PointerEvent) => void;
 	onmouseenter: () => void;
 	onmouseleave: () => void;
+	onfocus: () => void;
+	onblur: () => void;
+	onkeydown: (event: KeyboardEvent) => void;
 }
 
 /** Reactive state returned by the line progress hook. */
@@ -108,6 +115,7 @@ export interface UseProgressLineProps {
 	getCustomThickness: () => ScenaProgressComponentThickness;
 	getSize: () => ComponentSize;
 	getProgress: () => number;
+	getStep: () => number;
 }
 
 /** Seek event callbacks used internally by the line progress hook. */
@@ -124,6 +132,7 @@ export interface UseProgressCircleProps {
 	getSize: () => ComponentSize;
 	getProgress: () => number;
 	getBuffer: () => number;
+	getStep: () => number;
 }
 
 /** Seek event callbacks used internally by the circle progress hook. */
@@ -142,6 +151,9 @@ export interface UseProgressCircleReturnEvents {
 	onpointercancel: (event: PointerEvent) => void;
 	onmouseenter: () => void;
 	onmouseleave: () => void;
+	onfocus: () => void;
+	onblur: () => void;
+	onkeydown: (event: KeyboardEvent) => void;
 }
 
 /** DOM element references for the linear progress bar. */

--- a/src/shared/ui/scena-progress/ui/ScenaProgressCircle.svelte
+++ b/src/shared/ui/scena-progress/ui/ScenaProgressCircle.svelte
@@ -13,9 +13,11 @@
 	let {
 		id,
 		size = ComponentSize.MD,
+		step = 0.05,
 		buffer = 0,
 		progress = 0,
 		hasBuffer,
+		valueText,
 		aria = { ariaLabel: 'Progress' },
 		customThickness,
 		customClasses,
@@ -53,6 +55,7 @@
 		getRootElement: () => rootElement,
 		getProgress: () => progress,
 		getBuffer: () => buffer,
+		getStep: () => step,
 		getSize: () => size,
 		onSeek: (progress, event) => onSeek?.(progress, event),
 		onSeekStart: (event: Event) => onSeekStart?.(event),
@@ -103,8 +106,9 @@
 	aria-valuenow={progress * 100}
 	aria-valuemin={0}
 	aria-valuemax={100}
-	aria-valuetext="{Math.round(progress * 100)}%"
+	aria-valuetext={valueText}
 	xmlns="http://www.w3.org/2000/svg"
+	{...progressCircle.events}
 >
 	{#if progressCircle.radialSize}
 		<circle
@@ -164,7 +168,6 @@
 			fill="none"
 			stroke="transparent"
 			stroke-width={progressCircle.hitAreaThickness}
-			{...progressCircle.events}
 		/>
 	{/if}
 </svg>

--- a/src/shared/ui/scena-progress/ui/ScenaProgressLine.svelte
+++ b/src/shared/ui/scena-progress/ui/ScenaProgressLine.svelte
@@ -13,9 +13,11 @@
 	let {
 		id,
 		size = ComponentSize.MD,
+		step = 0.05,
 		buffer = 0,
 		progress = 0,
 		hasBuffer,
+		valueText,
 		aria = { ariaLabel: 'Progress' },
 		customThickness,
 		customClasses,
@@ -61,6 +63,7 @@
 	const progressLine = useProgressLine({
 		getRootElement: () => rootElement!,
 		getProgress: () => progress,
+		getStep: () => step,
 		getSize: () => size,
 		onSeek: (progress, event) => onSeek?.(progress, event),
 		onSeekStart: (event: Event) => onSeekStart?.(event),
@@ -87,14 +90,14 @@
 	aria-valuenow={progress * 100}
 	aria-valuemin={0}
 	aria-valuemax={100}
-	aria-valuetext="{Math.round(progress * 100)}%"
+	aria-valuetext={valueText}
+	{...progressLine.events}
 >
 	<div
 		bind:this={trackElement}
 		class={trackClasses}
 		style={trackStyles}
 		style:height="{progressLine.thickness}px"
-		{...progressLine.events}
 	>
 		{#if hasBuffer}
 			<div

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -2,3 +2,4 @@ export { formatComponentStyleProperty, formatComponentStyles, resolveElements } 
 export { isBrowser, assertBrowser } from './environment';
 export { ScenaError } from './errors';
 export { deepClone, deepMerge, pick } from './objects';
+export { formatTime } from './time';

--- a/src/shared/utils/time/format-time/index.ts
+++ b/src/shared/utils/time/format-time/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Formats a duration in seconds as a clock string.
+ *
+ * Negative, `NaN` or `Infinity` inputs are treated as `0`.
+ *
+ * @example
+ * formatTime(45) // "0:45"
+ * formatTime(150) // "2:30"
+ * formatTime(3661) // "1:01:01"
+ */
+export function formatTime(seconds: number): string {
+	const safeSeconds = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+
+	const hours = Math.floor(safeSeconds / 3600);
+	const minutes = Math.floor((safeSeconds % 3600) / 60);
+	const secs = safeSeconds % 60;
+
+	const paddedSecs = secs.toString().padStart(2, '0');
+
+	if (hours > 0) {
+		const paddedMinutes = minutes.toString().padStart(2, '0');
+
+		return `${hours}:${paddedMinutes}:${paddedSecs}`;
+	}
+
+	return `${minutes}:${paddedSecs}`;
+}

--- a/src/shared/utils/time/index.ts
+++ b/src/shared/utils/time/index.ts
@@ -1,0 +1,1 @@
+export { formatTime } from './format-time';

--- a/src/widgets/scena-video-container/model/types/index.ts
+++ b/src/widgets/scena-video-container/model/types/index.ts
@@ -23,6 +23,11 @@ export interface ScenaVideoContainerProps {
 	size: ComponentSize;
 	/** Shape of the video container (affects aspect ratio and border-radius). */
 	shape: ComponentShape;
+	/**
+	 * Turns the container into a single focusable button and makes its
+	 * content inert. Enabled by the preview feature while previewing.
+	 */
+	isInteractive: boolean;
 	/** ARIA attributes for accessibility. */
 	aria: Partial<ComponentAriaProps>;
 	customClasses: Partial<ScenaVideoContainerCustomClasses>;

--- a/src/widgets/scena-video-container/ui/ScenaVideoContainer.svelte
+++ b/src/widgets/scena-video-container/ui/ScenaVideoContainer.svelte
@@ -14,6 +14,7 @@
 		id,
 		size = ComponentSize.MD,
 		shape = ComponentShape.CIRCLE,
+		isInteractive = false,
 		aria,
 		customClasses,
 		customStyles,
@@ -33,11 +34,17 @@
 
 	const rootStyles = $derived(formatComponentStyles(customStyles?.root));
 
+	const tabindex = $derived(isInteractive ? 0 : -1);
+
 	function onVideoContainerClick(event: MouseEvent) {
 		eventEmitter.emit(ScenaEvent.ON_VIDEO_CONTAINER_CLICK, event);
 	}
 
 	function onVideoContainerKeydown(event: KeyboardEvent) {
+		if (event.target !== rootElement) {
+			return;
+		}
+
 		if (event.key === 'Enter' || event.key === ' ') {
 			event.preventDefault();
 			eventEmitter.emit(ScenaEvent.ON_VIDEO_CONTAINER_CLICK, event);
@@ -65,7 +72,7 @@
 	aria-haspopup={aria?.ariaHaspopup}
 	aria-pressed={aria?.ariaPressed}
 	role="button"
-	tabindex="0"
+	{tabindex}
 	onclick={onVideoContainerClick}
 	onkeydown={onVideoContainerKeydown}
 >

--- a/src/widgets/scena-video-progress/model/types/index.ts
+++ b/src/widgets/scena-video-progress/model/types/index.ts
@@ -43,6 +43,7 @@ export interface ScenaVideoProgressProps {
 	id: string;
 	size: ComponentSize;
 	shape: ComponentShape;
+	step: number;
 	hasBuffer: boolean;
 	aria: Partial<ComponentAriaProps>;
 	customThickness: Partial<ScenaVideoProgressComponentThickness>;

--- a/src/widgets/scena-video-progress/ui/ScenaVideoProgress.svelte
+++ b/src/widgets/scena-video-progress/ui/ScenaVideoProgress.svelte
@@ -2,6 +2,7 @@
 	import { getScenaVideoContext, ScenaVideoState } from '@/entities/video';
 	import { ComponentSize, ComponentShape } from '@/shared/enums';
 	import { ScenaProgressLine, ScenaProgressCircle } from '@/shared/ui/scena-progress';
+	import { formatTime } from '@/shared/utils';
 
 	import type { ScenaVideoProgressElements, ScenaVideoProgressProps } from '../model';
 
@@ -9,6 +10,7 @@
 		id,
 		size = ComponentSize.MD,
 		shape = ComponentShape.CIRCLE,
+		step = 0.05,
 		hasBuffer = true,
 		customThickness,
 		customClasses,
@@ -29,6 +31,12 @@
 	const isLine = $derived(linearShapes.includes(shape));
 
 	const isCircle = $derived(circleShapes.includes(shape));
+
+	const currentValueText = $derived(formatTime(scenaVideoContext.currentTime));
+
+	const durationValueText = $derived(formatTime(scenaVideoContext.duration));
+
+	const valueText = $derived(`${currentValueText} / ${durationValueText}`);
 
 	function onSeek(progress: number): void {
 		const time = progress * scenaVideoContext.duration;
@@ -63,6 +71,8 @@
 		buffer={scenaVideoContext.buffer}
 		progress={scenaVideoContext.progress}
 		customThickness={customThickness?.line}
+		{step}
+		{valueText}
 		{hasBuffer}
 		{onSeek}
 		{onSeekStart}
@@ -79,6 +89,8 @@
 		buffer={scenaVideoContext.buffer}
 		progress={scenaVideoContext.progress}
 		customThickness={customThickness?.circle}
+		{step}
+		{valueText}
 		{hasBuffer}
 		{onSeek}
 		{onSeekStart}


### PR DESCRIPTION
## Summary

  In preview mode, keyboard users had to press Tab again after expanding the widget with Enter to reach the controls. Also, when preview was disabled, the container was still a focusable button that
  did nothing on Enter. The container is now a tab stop only while previewing, and focus moves to the first control automatically on expand.

  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [x] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes

  - New `isInteractive` prop on `ScenaVideoContainer`: controls `tabindex` (`0` in preview, `-1` otherwise), enabled by the preview feature via the PREVIEW override layer
  - On expand (Enter/click), focus is handed over to the first focusable control inside the container
  - On programmatic collapse (`preview.api.start()`), focus returns to the container if it was inside
  
  ## How to test

  1. Enable `preview` in the playground config (`playground/src/App.svelte`)
  2. Tab to the widget — it should be a single tab stop
  3. Press Enter — the widget expands and focus lands on the progress bar (no extra Tab needed)
  4. With `preview` disabled, Tab should skip the container and go straight to the controls

  ## Checklist 

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in