### PR TITLE
chore: run build before npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"validate": "npm run check && npm run lint",
+		"prepublishOnly": "npm run build",
 		"release": "release-it",
 		"release:dry": "release-it --dry-run"
 	},


### PR DESCRIPTION
## Summary

  Publishing to npm relied on a manually built `dist` — it was possible to publish a stale or missing build. The `prepublishOnly` hook now guarantees a fresh build on every `npm publish`.
  
  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [ ] New feature (non-breaking) 
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [x] Docs / tooling
  
  ## Changes

  - Added `prepublishOnly: npm run build` script to `package.json`
  
  ## How to test

  1. Run `npm publish --dry-run`
  2. Verify the build (`build:lib`, `build:types`, `build:styles`) runs automatically before packing

  ## Checklist 

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in