### PR TITLE
docs: update bundle size to ~35KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # @retoo/scena
 
 [![npm version](https://img.shields.io/npm/v/@retoo/scena)](https://www.npmjs.com/package/@retoo/scena)
-[![bundle size](https://img.shields.io/badge/gzipped-~30KB-blue)](https://use-retoo.github.io/scena/distribution/bundle-size)
+[![bundle size](https://img.shields.io/badge/gzipped-~35KB-blue)](https://use-retoo.github.io/scena/distribution/bundle-size)
 [![license](https://img.shields.io/badge/license-PolyForm%20Shield%201.0.0-blue)](./LICENSE.md)
 
-Embeddable video widget for any website. Framework-agnostic, SSR-safe, ~30KB gzipped.
+Embeddable video widget for any website. Framework-agnostic, SSR-safe, ~35KB gzipped.
 
 **[Documentation](https://use-retoo.github.io/scena)**
 


### PR DESCRIPTION
## Summary

  The README badge and description claimed ~30KB gzipped, but the actual bundle has grown to ~35KB. Updated the numbers to match reality.
  
  ## Type of change

  - [ ] Bug fix (non-breaking)
  - [ ] New feature (non-breaking) 
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [x] Docs / tooling

  ## Changes

  - Updated bundle size in README badge and description: ~30KB → ~35KB
  
  ## How to test

  1. Check the [bundle size report](https://use-retoo.github.io/scena/distribution/bundle-size) — README now matches it
  
  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in