### PR TITLE
test: add unit tests for shared utils

### DIFF
--- a/src/shared/utils/components/format-component-style-property/__tests__/formatComponentStyleProperty.test.ts
+++ b/src/shared/utils/components/format-component-style-property/__tests__/formatComponentStyleProperty.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatComponentStyleProperty } from '../index';
+
+describe('formatComponentStyleProperty', () => {
+	describe('basic functionality', () => {
+		it('should convert camelCase to kebab-case', () => {
+			expect(formatComponentStyleProperty('backgroundColor')).toBe('background-color');
+		});
+
+		it('should convert multiple uppercase letters', () => {
+			expect(formatComponentStyleProperty('borderTopLeftRadius')).toBe('border-top-left-radius');
+		});
+	});
+
+	describe('case handling', () => {
+		it('should leave already-lowercase property unchanged', () => {
+			expect(formatComponentStyleProperty('color')).toBe('color');
+		});
+
+		it('should prefix leading uppercase letter with a dash', () => {
+			expect(formatComponentStyleProperty('WebkitTransform')).toBe('-webkit-transform');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should return empty string for empty input', () => {
+			expect(formatComponentStyleProperty('')).toBe('');
+		});
+
+		it('should handle string without uppercase letters', () => {
+			expect(formatComponentStyleProperty('margin-top')).toBe('margin-top');
+		});
+	});
+});

--- a/src/shared/utils/components/format-component-styles/__tests__/formatComponentStyles.test.ts
+++ b/src/shared/utils/components/format-component-styles/__tests__/formatComponentStyles.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatComponentStyles } from '../index';
+
+describe('formatComponentStyles', () => {
+	describe('basic functionality', () => {
+		it('should convert a single-property object to a CSS string', () => {
+			expect(formatComponentStyles({ color: 'red' })).toBe('color: red;');
+		});
+
+		it('should convert multiple properties joined by semicolons', () => {
+			expect(formatComponentStyles({ color: 'red', backgroundColor: 'blue' })).toBe(
+				'color: red; background-color: blue;'
+			);
+		});
+
+		it('should kebab-case camelCase property names', () => {
+			expect(formatComponentStyles({ marginTop: '4px' })).toBe('margin-top: 4px;');
+		});
+	});
+
+	describe('case handling', () => {
+		it('should return a string value as-is', () => {
+			expect(formatComponentStyles('color: red; margin: 0')).toBe('color: red; margin: 0');
+		});
+
+		it('should return undefined when styles is undefined', () => {
+			expect(formatComponentStyles(undefined)).toBeUndefined();
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should return undefined for an empty string', () => {
+			expect(formatComponentStyles('')).toBeUndefined();
+		});
+
+		it('should return just a trailing semicolon for an empty object', () => {
+			expect(formatComponentStyles({})).toBe(';');
+		});
+	});
+});

--- a/src/shared/utils/components/resolve-elements/__tests__/resolveElements.test.ts
+++ b/src/shared/utils/components/resolve-elements/__tests__/resolveElements.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveElements } from '../index';
+
+describe('resolveElements', () => {
+	describe('basic functionality', () => {
+		it('should return the result of getElements', () => {
+			const elements = { root: 'node' };
+			const instance = { getElements: () => elements };
+
+			expect(resolveElements(instance)).toBe(elements);
+		});
+	});
+
+	describe('case handling', () => {
+		it('should return null when instance is null', () => {
+			expect(resolveElements(null)).toBeNull();
+		});
+
+		it('should return null when getElements returns null', () => {
+			const instance = { getElements: () => null };
+
+			expect(resolveElements<null>(instance)).toBeNull();
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should coerce an undefined getElements result to null', () => {
+			const instance = { getElements: () => undefined as unknown as { root: string } };
+
+			expect(resolveElements(instance)).toBeNull();
+		});
+	});
+});

--- a/src/shared/utils/errors/__tests__/ScenaError.test.ts
+++ b/src/shared/utils/errors/__tests__/ScenaError.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+
+import { ScenaError } from '../index';
+
+describe('ScenaError', () => {
+	describe('basic functionality', () => {
+		it('should set the provided message', () => {
+			const error = new ScenaError('something went wrong');
+
+			expect(error.message).toBe('something went wrong');
+		});
+
+		it('should have the name ScenaError', () => {
+			const error = new ScenaError('boom');
+
+			expect(error.name).toBe('ScenaError');
+		});
+	});
+
+	describe('case handling', () => {
+		it('should be an instance of Error', () => {
+			const error = new ScenaError('boom');
+
+			expect(error).toBeInstanceOf(Error);
+		});
+
+		it('should be an instance of ScenaError', () => {
+			const error = new ScenaError('boom');
+
+			expect(error).toBeInstanceOf(ScenaError);
+		});
+
+		it('should be throwable and catchable as ScenaError', () => {
+			expect(() => {
+				throw new ScenaError('boom');
+			}).toThrow(ScenaError);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle an empty message', () => {
+			const error = new ScenaError('');
+
+			expect(error.message).toBe('');
+			expect(error.name).toBe('ScenaError');
+		});
+	});
+});

--- a/src/shared/utils/time/format-time/__tests__/formatTime.test.ts
+++ b/src/shared/utils/time/format-time/__tests__/formatTime.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatTime } from '../index';
+
+describe('formatTime', () => {
+	describe('basic functionality', () => {
+		it('should format seconds as m:ss', () => {
+			expect(formatTime(45)).toBe('0:45');
+		});
+
+		it('should format minutes and seconds', () => {
+			expect(formatTime(150)).toBe('2:30');
+		});
+
+		it('should format hours, minutes and seconds', () => {
+			expect(formatTime(3661)).toBe('1:01:01');
+		});
+	});
+
+	describe('case handling', () => {
+		it('should pad seconds to two digits', () => {
+			expect(formatTime(5)).toBe('0:05');
+		});
+
+		it('should not pad minutes when no hours', () => {
+			expect(formatTime(305)).toBe('5:05');
+		});
+
+		it('should pad minutes to two digits when hours present', () => {
+			expect(formatTime(3725)).toBe('1:02:05');
+		});
+
+		it('should floor fractional seconds', () => {
+			expect(formatTime(45.9)).toBe('0:45');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should return 0:00 for zero', () => {
+			expect(formatTime(0)).toBe('0:00');
+		});
+
+		it('should treat negative input as zero', () => {
+			expect(formatTime(-10)).toBe('0:00');
+		});
+
+		it('should treat NaN as zero', () => {
+			expect(formatTime(NaN)).toBe('0:00');
+		});
+
+		it('should treat Infinity as zero', () => {
+			expect(formatTime(Infinity)).toBe('0:00');
+		});
+
+		it('should handle exactly one hour', () => {
+			expect(formatTime(3600)).toBe('1:00:00');
+		});
+	});
+});

--- a/test.setup.globals.ts
+++ b/test.setup.globals.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Provides `__NAME__` / `__VERSION__` as real runtime globals for tests.
+ *
+ * In the production build these are inlined by Vite's `define`, but relying on
+ * that compile-time substitution inside Vitest is fragile: the transformed
+ * module is cached in `node_modules/.vite`, and under parallel runs (e.g. the
+ * lefthook pre-commit hook) the dep-optimizer cache can race and drop the
+ * substitution, leaving a bare `__NAME__` reference -> `ReferenceError`.
+ *
+ * Setup files run fresh on every test execution and are not cached, so defining
+ * the globals here makes the values cache- and race-proof.
+ */
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as {
+	name: string;
+	version: string;
+};
+
+Object.assign(globalThis, {
+	__NAME__: pkg.name,
+	__VERSION__: pkg.version
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,6 +6,6 @@
 		"types": ["svelte", "vite/client", "@testing-library/jest-dom"]
 	},
 
-	"include": ["src/**/*.test.ts", "test.setup.ts", "vite.test.config.ts"],
+	"include": ["src/**/*.test.ts", "test.setup.ts", "test.setup.globals.ts", "vite.test.config.ts"],
 	"exclude": []
 }

--- a/vite.test.config.ts
+++ b/vite.test.config.ts
@@ -1,19 +1,11 @@
-import { readFileSync } from 'node:fs';
 import { fileURLToPath, URL } from 'node:url';
 
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vitest/config';
 
-const { version, name } = JSON.parse(readFileSync('./package.json', 'utf-8'));
-
 const alias = {
 	'@': fileURLToPath(new URL('./src', import.meta.url))
-};
-
-const define = {
-	__VERSION__: JSON.stringify(version),
-	__NAME__: JSON.stringify(name)
 };
 
 export default defineConfig({
@@ -22,21 +14,20 @@ export default defineConfig({
 			{
 				plugins: [svelte()],
 				resolve: { alias },
-				define,
 				test: {
 					name: 'unit',
 					include: ['src/**/*.test.ts'],
-					exclude: ['src/**/ui/**/*.test.ts']
+					exclude: ['src/**/ui/**/*.test.ts'],
+					setupFiles: ['./test.setup.globals.ts']
 				}
 			},
 			{
 				plugins: [svelte(), svelteTesting()],
 				resolve: { alias },
-				define,
 				test: {
 					name: 'ui',
 					include: ['src/**/ui/**/*.test.ts'],
-					setupFiles: ['./test.setup.ts'],
+					setupFiles: ['./test.setup.globals.ts', './test.setup.ts'],
 					environment: 'jsdom'
 				}
 			}


### PR DESCRIPTION
## Summary

  Adds unit tests for the pure utils in `src/shared/utils/`, and fixes a flaky
  `__NAME__ is not defined` error that surfaced when the lefthook pre-commit hook
  runs lint/check/test in parallel.

  ## Type of change

  - [x] Bug fix (non-breaking)
  - [ ] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [ ] Refactor / internal (no behaviour change)
  - [x] Docs / tooling

  ## Changes

  - Add unit tests: `formatTime`, `formatComponentStyleProperty`, `formatComponentStyles`, `ScenaError`, `resolveElements`
  - Inject `__NAME__` / `__VERSION__` as runtime globals via a new test setup file instead of relying on Vite's compile-time `define` in tests
  - Apply the globals setup to both the `unit` and `ui` test projects; drop `define` from `vite.test.config.ts` (kept in `vite.config.ts` for builds)

  ## How to test

  1. `rm -rf node_modules/.vite && ( npm run lint & npm run check & npm run test & wait )` — passes without `__NAME__ is not defined` (previously raced under the parallel pre-commit hook)
  2. `npm test` — 418 tests pass

  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in