### PR TITLE
refactor: simplify visibility apply logic

### DIFF
--- a/src/app/entrypoint/model/lib/useScena.svelte.ts
+++ b/src/app/entrypoint/model/lib/useScena.svelte.ts
@@ -75,7 +75,7 @@ export default function useScena(): UseScenaReturns {
 						const scena = component as Scena;
 
 						scena.api.events.on(ScenaEvent.ON_VIDEO_READY, () => {
-							if (visibility.api.isShownOnReady) {
+							if (visibility.api.isShownOnReady && !visibility.api.isHidden) {
 								visibility.api.show();
 							}
 						});

--- a/src/app/entrypoint/modules/scena-visibility/lib/__tests__/useScenaVisibility.test.ts
+++ b/src/app/entrypoint/modules/scena-visibility/lib/__tests__/useScenaVisibility.test.ts
@@ -109,7 +109,7 @@ describe('useScenaVisibility', () => {
 	});
 
 	describe('apply', () => {
-		it('should resolve defaults when isShownOnReady is false', () => {
+		it('should not affect isHidden when only isShownOnReady is set', () => {
 			const config = useScenaConfig({
 				video: {
 					src: ''
@@ -130,7 +130,7 @@ describe('useScenaVisibility', () => {
 			});
 		});
 
-		it('should set isHidden to true when isShownOnReady is true and isHidden is not set', () => {
+		it('should default isHidden to false when only isShownOnReady is true', () => {
 			const config = useScenaConfig({
 				video: {
 					src: ''
@@ -143,7 +143,26 @@ describe('useScenaVisibility', () => {
 			visibility.apply();
 
 			expect(config.getConfig().visibility).toEqual({
-				isHidden: true,
+				isHidden: false,
+				isAnimated: true,
+				isShownOnReady: true
+			});
+		});
+
+		it('should not affect isShownOnReady when only isHidden is set', () => {
+			const config = useScenaConfig({
+				video: {
+					src: ''
+				},
+				visibility: { isHidden: false }
+			});
+
+			const visibility = useScenaVisibility(config, useEventEmitter());
+
+			visibility.apply();
+
+			expect(config.getConfig().visibility).toEqual({
+				isHidden: false,
 				isAnimated: true,
 				isShownOnReady: true
 			});
@@ -183,7 +202,7 @@ describe('useScenaVisibility', () => {
 			visibility.apply();
 
 			expect(config.getConfig().visibility).toEqual({
-				isHidden: true,
+				isHidden: false,
 				isAnimated: true,
 				isShownOnReady: true
 			});

--- a/src/app/entrypoint/modules/scena-visibility/lib/useScenaVisibility.svelte.ts
+++ b/src/app/entrypoint/modules/scena-visibility/lib/useScenaVisibility.svelte.ts
@@ -21,32 +21,11 @@ export default function useScenaVisibility(
 	function apply() {
 		const visibility = config.getConfig().visibility;
 
-		const hasAnimatedProperty = typeof visibility?.isAnimated === 'boolean';
+		const isAnimated = visibility?.isAnimated ?? true;
 
-		const hasShownOnReadyProperty = typeof visibility?.isShownOnReady === 'boolean';
+		const isHidden = visibility?.isHidden ?? false;
 
-		const hasHiddenProperty = typeof visibility?.isHidden === 'boolean';
-
-		const isAnimated = hasAnimatedProperty ? visibility?.isAnimated : true;
-
-		let isHidden = true;
-
-		let isShownOnReady = true;
-
-		if (hasHiddenProperty && hasShownOnReadyProperty) {
-			isHidden = visibility!.isHidden!;
-			isShownOnReady = visibility!.isShownOnReady!;
-		}
-
-		if (hasHiddenProperty && !hasShownOnReadyProperty) {
-			isHidden = visibility!.isHidden!;
-			isShownOnReady = !visibility!.isHidden!;
-		}
-
-		if (!hasHiddenProperty && hasShownOnReadyProperty) {
-			isShownOnReady = visibility!.isShownOnReady!;
-			isHidden = visibility!.isShownOnReady!;
-		}
+		const isShownOnReady = visibility?.isShownOnReady ?? true;
 
 		config.mergeConfig({
 			visibility: {


### PR DESCRIPTION
## Summary

  Make `isHidden` the single source of truth for widget display. `apply()` now resolves each `visibility` field independently (no cross-coupling), and auto-show on video ready never overrides an
  explicit `isHidden: true`.

  ## Type of change
  
  - [x] Bug fix (non-breaking)
  - [ ] New feature (non-breaking)
  - [ ] Breaking change (fixes or features that would cause existing functionality to change)
  - [x] Refactor / internal (no behaviour change)
  - [ ] Docs / tooling

  ## Changes
  
  - `useScenaVisibility.apply()`: replaced the branching `has*Property` resolution with per-field defaults via `??` — `isHidden ?? false`, `isShownOnReady ?? true`, `isAnimated ?? true`. Fields are no
  longer derived from each other.
  - `useScena` `ON_VIDEO_READY` handler: auto-show is now guarded by `isShownOnReady && !isHidden`, so a widget configured with `isHidden: true` stays hidden even when `isShownOnReady` is `true`.
  - `isHidden` default aligned to `false` across resolve/UI/unmount (previously `apply()` defaulted to `true` while the UI defaulted to `false`).
  - Updated unit tests to assert the decoupled resolution and the guarded auto-show.

  ## Breaking changes

  - `{ isHidden: true, isShownOnReady: true }` now keeps the widget **hidden** (previously auto-show on `ON_VIDEO_READY` revealed it). `isHidden` always wins.
  - Default (no `visibility` / no `isHidden`) is now `isHidden: false` — the widget is visible immediately rather than starting hidden and revealing on video ready.

  Migration: if you relied on auto-show overriding `isHidden`, drop `isHidden: true` (or call `show()` manually).

  ## How to test

  1. `npm test` — 419/419 pass (or `npx vitest run --config vite.test.config.ts src/app/entrypoint/modules/scena-visibility` for the visibility suite only).
  2. Config `{ visibility: { isHidden: true, isShownOnReady: true } }` keeps the widget hidden after `ON_VIDEO_READY`.
  3. Config `{ visibility: { isShownOnReady: true } }` (or no `visibility`) shows the widget.

  ## Checklist

  - [x] `npm run validate` passes locally (lint + typecheck)
  - [x] `npm test` passes (419/419)
  - [x] Commit messages follow Conventional Commits
  - [x] No unrelated refactors mixed in